### PR TITLE
Start uid only for composers

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -678,7 +678,7 @@ def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
         uid = str(uuid.uuid4())
     counter = itertools.count()
     doc = {'uid': uid,
-           'run_start': start['uid'],
+           'run_start': start,
            'spec': spec,
            'root': root,
            'resource_path': resource_path,
@@ -706,7 +706,7 @@ def compose_stop(*, start, event_counter, poison_pill,
         time = ttime.time()
     doc = {'uid': uid,
            'time': time,
-           'run_start': start['uid'],
+           'run_start': start,
            'exit_status': exit_status,
            'reason': reason,
            'num_events': dict(event_counter)}
@@ -798,7 +798,7 @@ def compose_descriptor(*, start, streams, event_counter,
         hints = {}
     doc = {'uid': uid,
            'time': time,
-           'run_start': start['uid'],
+           'run_start': start,
            'name': name,
            'data_keys': data_keys,
            'object_keys': object_keys,
@@ -854,10 +854,10 @@ def compose_run(*, uid=None, time=None, metadata=None, validate=True):
         jsonschema.validate(doc, schemas[DocumentNames.start])
     return ComposeRunBundle(
         doc,
-        partial(compose_descriptor, start=doc, streams=streams,
+        partial(compose_descriptor, start=doc['uid'], streams=streams,
                 event_counter=event_counter),
-        partial(compose_resource, start=doc),
-        partial(compose_stop, start=doc, event_counter=event_counter,
+        partial(compose_resource, start=doc['uid']),
+        partial(compose_stop, start=doc['uid'], event_counter=event_counter,
                 poison_pill=poison_pill))
 
 

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -159,7 +159,7 @@ def test_round_trip_pagination():
     assert actual == expected
 
 
-def test_bulk_events_to_event_page(tmp_path):
+def test_bulk_events_to_event_page(tmpdir):
     run_bundle = event_model.compose_run()
     desc_bundle = run_bundle.compose_descriptor(
         data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
@@ -170,7 +170,7 @@ def test_bulk_events_to_event_page(tmp_path):
         data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
         name='baseline')
 
-    path_root = str(tmp_path)
+    path_root = str(tmpdir)
 
     res_bundle = run_bundle.compose_resource(
         spec='TIFF', root=path_root, resource_path='stack.tiff',
@@ -284,20 +284,20 @@ def test_document_router_smoke_test():
     dr('stop', run_bundle.compose_stop())
 
 
-def test_filler(tmp_path):
+def test_filler(tmpdir):
 
     class DummyHandler:
         def __init__(self, resource_path, a, b):
             assert a == 1
             assert b == 2
-            assert resource_path == str(tmp_path / "stack.tiff")
+            assert resource_path == str(tmpdir / "stack.tiff")
 
         def __call__(self, c, d):
             assert c == 3
             assert d == 4
             return numpy.ones((5, 5))
 
-    path_root = str(tmp_path)
+    path_root = str(tmpdir)
 
     reg = {'DUMMY': DummyHandler}
     filler = event_model.Filler(reg)
@@ -420,7 +420,7 @@ def test_filler(tmp_path):
         def __init__(self, resource_path, a, b):
             assert a == 1
             assert b == 2
-            assert resource_path == str(tmp_path / "moved" / "stack.tiff")
+            assert resource_path == str(tmpdir / "moved" / "stack.tiff")
 
         def __call__(self, c, d):
             assert c == 3
@@ -428,7 +428,7 @@ def test_filler(tmp_path):
             return numpy.ones((5, 5))
 
     with event_model.Filler({'DUMMY': DummyHandlerRootMapTest},
-                            root_map={path_root: str(tmp_path / "moved")}
+                            root_map={path_root: str(tmpdir / "moved")}
                             ) as filler:
 
         filler('start', run_bundle.start_doc)


### PR DESCRIPTION
Only use start uid in composers so we don't need to cache the entire start

Previously the composers expected then entire start doc just to pull out the
uid, now they expect the uid.