### PR TITLE
build schema_validators dict for bluesky issue #1197

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -635,6 +635,25 @@ for name, filename in SCHEMA_NAMES.items():
     with open(rs_fn('event_model', filename)) as fin:
         schemas[name] = json.load(fin)
 
+
+def _is_array(checker, instance):
+    return (
+        jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or
+        isinstance(instance, tuple)
+    )
+
+
+_array_type_checker = jsonschema.validators.Draft7Validator.TYPE_CHECKER.redefine('array', _is_array)
+
+
+_Validator = jsonschema.validators.extend(
+    jsonschema.validators.Draft7Validator,
+    type_checker=_array_type_checker)
+
+
+schema_validators = {name: _Validator(schema=schema) for name, schema in schemas.items()}
+
+
 __version__ = get_versions()['version']
 del get_versions
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1,7 +1,5 @@
 from collections import defaultdict, deque, namedtuple
 import json
-import jsonschema
-import numpy
 from enum import Enum
 from functools import partial
 import itertools
@@ -10,11 +8,13 @@ from pkg_resources import resource_filename as rs_fn
 import time as ttime
 import uuid
 import warnings
+
+import jsonschema
+import numpy
+
 from ._version import get_versions
 
-__all__ = ['DocumentNames', 'schemas', 'compose_run']
-
-_validate = partial(jsonschema.validate, types={'array': (list, tuple)})
+__all__ = ['DocumentNames', 'schemas', 'schema_validators', 'compose_run']
 
 
 class DocumentNames(Enum):
@@ -70,8 +70,7 @@ class DocumentRouter:
         """
         output_doc = getattr(self, name)(doc)
         if validate:
-            jsonschema.validate(output_doc,
-                                schemas[getattr(DocumentNames, name)])
+            schema_validators[DocumentNames.name].validate(output_doc)
         return (name, output_doc if output_doc is not None else doc)
 
     def start(self, doc):
@@ -672,7 +671,7 @@ def compose_datum(*, resource, counter, datum_kwargs, validate=True):
            'datum_kwargs': datum_kwargs,
            'datum_id': '{}/{}'.format(resource_uid, next(counter))}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.datum])
+        schema_validators[DocumentNames.datum].validate(doc)
     return doc
 
 
@@ -684,7 +683,7 @@ def compose_datum_page(*, resource, counter, datum_kwargs, validate=True):
            'datum_kwargs': datum_kwargs,
            'datum_id': ['{}/{}'.format(resource_uid, next(counter)) for _ in range(N)]}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.datum])
+        schema_validators[DocumentNames.datum].validate(doc)
     return doc
 
 
@@ -704,7 +703,8 @@ def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
            'resource_kwargs': resource_kwargs,
            'path_semantics': path_semantics}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.resource])
+        schema_validators[DocumentNames.resource].validate(doc)
+
     return ComposeResourceBundle(
         doc,
         partial(compose_datum, resource=doc, counter=counter),
@@ -730,7 +730,7 @@ def compose_stop(*, start, event_counter, poison_pill,
            'reason': reason,
            'num_events': {k: v - 1 for k, v in event_counter.items()}}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.stop])
+        schema_validators[DocumentNames.stop].validate(doc)
     return doc
 
 
@@ -751,7 +751,7 @@ def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
            'filled': filled,
            'descriptor': descriptor['uid']}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.event_page])
+        schema_validators[DocumentNames.event_page].validate(doc)
         if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
             raise EventModelValidationError(
                 "These sets of keys must match:\n"
@@ -785,7 +785,7 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num=None,
            'filled': filled,
            'descriptor': descriptor['uid']}
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.event])
+        schema_validators[DocumentNames.event].validate(doc)
         if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
             raise EventModelValidationError(
                 "These sets of keys must match:\n"
@@ -830,7 +830,7 @@ def compose_descriptor(*, start, streams, event_counter,
                 "data_keys {}. The requested data_keys were {}. All "
                 "descriptors in a given stream must have the same "
                 "data_keys.".format(name, streams[name], set(data_keys)))
-        jsonschema.validate(doc, schemas[DocumentNames.descriptor])
+        schema_validators[DocumentNames.descriptor].validate(doc)
     if name not in streams:
         streams[name] = set(data_keys)
         event_counter[name] = 1
@@ -870,7 +870,8 @@ def compose_run(*, uid=None, time=None, metadata=None, validate=True):
     event_counter = {}
     poison_pill = []
     if validate:
-        jsonschema.validate(doc, schemas[DocumentNames.start])
+        schema_validators[DocumentNames.start].validate(doc)
+
     return ComposeRunBundle(
         doc,
         partial(compose_descriptor, start=doc, streams=streams,

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -23,6 +23,13 @@ def test_schemas():
         assert event_model.schemas[k]
 
 
+def test_schema_validators():
+    for name in event_model.schemas.keys():
+        assert name in event_model.schema_validators
+
+    assert len(event_model.schema_validators) == len(event_model.schemas)
+
+
 def test_compose_run():
     # Compose each kind of document type. These calls will trigger
     # jsonschema.validate and ensure that the document-generation code composes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jsonschema
+jsonschema>=3.0.0
 numpy


### PR DESCRIPTION
A dict 'schema_validators' is constructed of jsonschema.Validator instances. The intention is that this dict be imported by code wanting to validate JSON.

## Motivation and Context
This change is in support of using jsonschema>3: https://github.com/bluesky/bluesky/issues/1197.

jsonschema.validate() is currently used in bluesky but has been deprecated. The 'new' method is to extend a jsonschema validator class which takes about 4 lines of code. I suggest putting those 4 lines in event-model and caching one validator for each schema.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

