### PR TITLE
FIX: correct windows path semantics 'windows' -> 'nt'

### DIFF
--- a/event_model/schemas/resource.json
+++ b/event_model/schemas/resource.json
@@ -19,7 +19,7 @@
         "path_semantics": {
             "type": "string",
             "description": "Rules for joining paths",
-            "enum": ["posix", "windows"]
+            "enum": ["posix", "nt"]
         },
         "uid": {
             "type": "string",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrong path_semantics for Windows OS (found with @mrakitin).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running a bluesky-browser in demo mode on Windows, the following error appeared:
```py
.....
  File "C:\Users\greateyes\AppData\Local\conda\conda\envs\collection-2019-1.2-rsoxs\lib\site-packages\bluesky\run_engine.py", line 2320, in emit
    schema_validators[name].validate(doc)
  File "C:\Users\greateyes\AppData\Local\conda\conda\envs\collection-2019-1.2-rsoxs\lib\site-packages\jsonschema\validators.py", line 348, in validate
    raise error
jsonschema.exceptions.ValidationError: 'nt' is not one of ['posix', 'windows']

Failed validating 'enum' in schema['properties']['path_semantics']:
    {'description': 'Rules for joining paths',
     'enum': ['posix', 'windows'],
     'type': 'string'}

On instance['path_semantics']:
    'nt'
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in production.

<!--
## Screenshots (if appropriate):
-->
