### PR TITLE
Include foreign key in exception.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -533,7 +533,8 @@ class Filler(DocumentRouter):
                 try:
                     datum_doc = self._datum_cache[datum_id]
                 except KeyError as err:
-                    err_with_key = UnresolvableForeignKeyError(datum_id,
+                    err_with_key = UnresolvableForeignKeyError(
+                        datum_id,
                         f"Event with uid {doc['uid']} refers to unknown Datum "
                         f"datum_id {datum_id}")
                     raise err_with_key from err
@@ -542,7 +543,8 @@ class Filler(DocumentRouter):
                 try:
                     resource = self._resource_cache[resource_uid]
                 except KeyError as err:
-                    raise UnresolvableForeignKeyError(resource_uid,
+                    raise UnresolvableForeignKeyError(
+                        resource_uid,
                         f"Datum with id {datum_id} refers to unknown Resource "
                         f"uid {resource_uid}") from err
                 # Look up the cached handler instance, or instantiate one.

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -533,11 +533,10 @@ class Filler(DocumentRouter):
                 try:
                     datum_doc = self._datum_cache[datum_id]
                 except KeyError as err:
-                    err_with_key = UnresolvableForeignKeyError(
+                    raise UnresolvableForeignKeyError(
                         datum_id,
                         f"Event with uid {doc['uid']} refers to unknown Datum "
-                        f"datum_id {datum_id}")
-                    raise err_with_key from err
+                        f"datum_id {datum_id}") from err
                 resource_uid = datum_doc['resource']
                 # Look up the cached Resource.
                 try:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1231,7 +1231,7 @@ def bulk_events_to_event_pages(bulk_events):
     # This is for a deprecated document type, so we are not being fussy
     # about efficiency/laziness here.
     event_pages = {}  # descriptor uid mapped to page
-    for stream_name, events in bulk_events.items():
+    for events in bulk_events.values():
         for event in events:
             descriptor = event['descriptor']
             try:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -533,17 +533,16 @@ class Filler(DocumentRouter):
                 try:
                     datum_doc = self._datum_cache[datum_id]
                 except KeyError as err:
-                    err_with_key = UnresolvableForeignKeyError(
+                    err_with_key = UnresolvableForeignKeyError(datum_id,
                         f"Event with uid {doc['uid']} refers to unknown Datum "
                         f"datum_id {datum_id}")
-                    err_with_key.key = datum_id
                     raise err_with_key from err
                 resource_uid = datum_doc['resource']
                 # Look up the cached Resource.
                 try:
                     resource = self._resource_cache[resource_uid]
                 except KeyError as err:
-                    raise UnresolvableForeignKeyError(
+                    raise UnresolvableForeignKeyError(resource_uid,
                         f"Datum with id {datum_id} refers to unknown Resource "
                         f"uid {resource_uid}") from err
                 # Look up the cached handler instance, or instantiate one.
@@ -669,7 +668,9 @@ class DataNotAccessible(EventModelError, IOError):
 
 class UnresolvableForeignKeyError(EventModelValueError):
     """when we see a foreign before we see the thing to which it refers"""
-    ...
+    def __init__(self, key, message):
+        self.key = key
+        self.message = message
 
 
 SCHEMA_PATH = 'schemas'

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -536,7 +536,7 @@ def test_rechunk_event_pages():
         """
         data_keys = ['x', 'y', 'z']
         array_keys = ['seq_num', 'time', 'uid']
-        for i in range(num_pages):
+        for _ in range(num_pages):
             yield {'descriptor': 'DESCRIPTOR',
                    **{key: list(range(page_size)) for key in array_keys},
                    'data': {key: list(range(page_size)) for key in data_keys},
@@ -562,7 +562,7 @@ def test_rechunk_datum_pages():
         """
         data_keys = ['x', 'y', 'z']
         array_keys = ['datum_id']
-        for i in range(num_pages):
+        for _ in range(num_pages):
             yield {'resource': 'RESOURCE',
                    **{key: list(range(page_size)) for key in array_keys},
                    'datum_kwargs': {key: list(range(page_size))


### PR DESCRIPTION
At two places in the code, we can raise
``UnresolveableForeignKeyError``. One is when we encounter a datum_id
that we don't recognize and the other is when we encounter a
resource_uid that we don't recognize.

Currently, in the first case, we monkey-patch the relevant key onto the
exception, but in the second case, we don't.

In this PR, the second case includes the key too. And, in both cases, we
avoid monkey-patching and instead pass the relevant key to the
``__init__`` of ``UnresolveableForeignKeyError``. This is motivated by
[examples in the Python documentation](https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions)
showing that it's OK for user-defined exceptions to have custom
signatures, which I was not sure of when I wrote the first verison of
this code.

This PR also includes some minor unrelated flake8 fixes that came up in
a recent upgrade to flake8.