### PR TITLE
Add Filler.get_handler.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -507,7 +507,20 @@ class Filler(DocumentRouter):
             return filled_doc
 
     def get_handler(self, resource):
-        # Look up the cached handler instance, or instantiate one.
+        """
+        Return a Handler instance for this Resource.
+
+        Parameters
+        ----------
+        resource: dict
+
+        Returns
+        -------
+        handler: Handler
+        """
+        if self._closed:
+            raise EventModelRuntimeError(
+                "This Filler has been closed and is no longer usable.")
         try:
             handler = self._handler_cache[resource['uid']]
         except KeyError:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -338,8 +338,18 @@ def test_filler(tmp_path):
     filler('stop', stop_doc)
     assert event['data']['image'].shape == (5, 5)
     assert not filler._closed
+
+    # Test get_handler() method.
+    handler = filler.get_handler(res_bundle.resource_doc)
+    # Repeated calls should return the exact same object (via caching).
+    assert filler.get_handler(res_bundle.resource_doc) is handler
+
+    # Test closing.
     filler.close()
-    assert filler._closed
+    with pytest.raises(event_model.EventModelRuntimeError):
+        filler.get_handler(res_bundle.resource_doc)
+    with pytest.raises(event_model.EventModelRuntimeError):
+        filler('stop', stop_doc)
 
     # Test context manager with Event.
     with event_model.Filler(reg, inplace=True) as filler:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -341,8 +341,9 @@ def test_filler(tmp_path):
 
     # Test get_handler() method.
     handler = filler.get_handler(res_bundle.resource_doc)
-    # Repeated calls should return the exact same object (via caching).
-    assert filler.get_handler(res_bundle.resource_doc) is handler
+    # The method does not expose the internal cache of handlers, so it should
+    # not return the same instance when called repeatedly.
+    assert filler.get_handler(res_bundle.resource_doc) is not handler
 
     # Test closing.
     filler.close()


### PR DESCRIPTION
This is a minor refactor that exposes the ability to hand the
Filler a Resource document and get back an instantiated Handler.

This is useful, for example, if you want to call
``handler.get_file_list(datum_kwargs_gen)``.

~Existing tests cover this sufficiently well.~ I thought better of it and added a specific test for this new method.