### PR TITLE
FIX: event_page and datum_page schemas

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -740,7 +740,7 @@ def compose_datum_page(*, resource, counter, datum_kwargs, validate=True):
            'datum_kwargs': datum_kwargs,
            'datum_id': ['{}/{}'.format(resource_uid, next(counter)) for _ in range(N)]}
     if validate:
-        schema_validators[DocumentNames.datum].validate(doc)
+        schema_validators[DocumentNames.datum_page].validate(doc)
     return doc
 
 
@@ -820,7 +820,7 @@ def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
             raise EventModelValidationError(
                 "Keys in event['filled'] {} must be a subset of those in "
                 "event['data'] {}".format(filled.keys(), data.keys()))
-    event_counter[descriptor['name']] += 1
+    event_counter[descriptor['name']] += len(data)
     return doc
 
 

--- a/event_model/schemas/datum_page.json
+++ b/event_model/schemas/datum_page.json
@@ -4,7 +4,9 @@
             "type": "object",
             "title": "dataframe",
             "description": "A DataFrame-like object",
-            "additionalProperties": {"type": "array"}
+            "additionalProperties": {
+                "type": "array"
+            }
         }
     },
     "properties": {
@@ -18,7 +20,9 @@
         },
         "datum_id": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+                "type": "string"
+            },
             "description": "Array unique identifiers for each Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
         }
     },

--- a/event_model/schemas/datum_page.json
+++ b/event_model/schemas/datum_page.json
@@ -1,6 +1,7 @@
 {
     "definitions": {
         "dataframe": {
+            "type": "object",
             "title": "dataframe",
             "description": "A DataFrame-like object",
             "additionalProperties": {"type": "array"}
@@ -12,7 +13,7 @@
             "description": "The UID of the Resource to which all Datums in the page belong"
         },
         "datum_kwargs": {
-            "type": "dataframe",
+            "$ref": "#/definitions/dataframe",
             "description": "Array of arguments to pass to the Handler to retrieve one quanta of data"
         },
         "datum_id": {

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -1,12 +1,14 @@
 {
     "definitions": {
         "dataframe": {
+            "type": "object",
             "title": "dataframe",
             "description": "A DataFrame-like object",
             "additionalProperties": {"type": "array"}
         },
         "dataframe_for_filled": {
             "title": "dataframe_for_filled",
+            "type": "object",
             "description": "A DataFrame-like object with boolean or string entries",
             "additionalProperties": {"type": "array", "items": {"type": ["boolean", "string"]}}
         }
@@ -17,15 +19,15 @@
             "description": "The UID of the EventDescriptor to which all of the Events in this page belong"
         },
         "data": {
-            "type": "dataframe",
+            "$ref": "#/definitions/dataframe",
             "description": "The actual measurement data"
         },
-        "timestamps": {
-            "type": "dataframe",
+        "timestamps":{
+            "$ref":"#/definitions/dataframe",
             "description": "The timestamps of the individual measurement data"
         },
         "filled": {
-            "type": "dataframe_for_filled",
+            "$ref":"#/definitions/dataframe_for_filled",
             "description": "Mapping each of the keys of externally-stored data to an array containing the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)"
         },
         "seq_num": {

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -4,13 +4,23 @@
             "type": "object",
             "title": "dataframe",
             "description": "A DataFrame-like object",
-            "additionalProperties": {"type": "array"}
+            "additionalProperties": {
+                "type": "array"
+            }
         },
         "dataframe_for_filled": {
             "title": "dataframe_for_filled",
             "type": "object",
             "description": "A DataFrame-like object with boolean or string entries",
-            "additionalProperties": {"type": "array", "items": {"type": ["boolean", "string"]}}
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": [
+                        "boolean",
+                        "string"
+                    ]
+                }
+            }
         }
     },
     "properties": {
@@ -22,27 +32,33 @@
             "$ref": "#/definitions/dataframe",
             "description": "The actual measurement data"
         },
-        "timestamps":{
-            "$ref":"#/definitions/dataframe",
+        "timestamps": {
+            "$ref": "#/definitions/dataframe",
             "description": "The timestamps of the individual measurement data"
         },
         "filled": {
-            "$ref":"#/definitions/dataframe_for_filled",
+            "$ref": "#/definitions/dataframe_for_filled",
             "description": "Mapping each of the keys of externally-stored data to an array containing the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)"
         },
         "seq_num": {
             "type": "array",
-            "items": {"type": "integer"},
+            "items": {
+                "type": "integer"
+            },
             "description": "Array of sequence numbers to identify the location of each Event in the Event stream"
         },
         "time": {
             "type": "array",
-            "items": {"type": "number"},
+            "items": {
+                "type": "number"
+            },
             "description": "Array of Event times. This maybe different than the timestamps on each of the data entries"
         },
         "uid": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+                "type": "string"
+            },
             "description": "Array of globally unique identifiers for each Event"
         }
     },

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -60,11 +60,19 @@ def test_compose_run():
     event_doc = compose_event(
         data={'motor': 0, 'image': datum_doc['datum_id']},
         timestamps={'motor': 0, 'image': 0}, filled={'image': False})
+    datum_page = compose_datum_page(datum_kwargs={'slice': [10, 15]})
+    event_page = compose_event_page(data={'motor': [1, 2], 'image':
+                                          datum_page['datum_id']},
+                                    timestamps={'motor': [0, 0],
+                                                'image': [0, 0]},
+                                    filled={'image': [False, False]},
+                                    seq_num=[1, 2])
     assert 'descriptor' in event_doc
+    assert 'descriptor' in event_page
     assert event_doc['seq_num'] == 1
     stop_doc = compose_stop()
     assert 'primary' in stop_doc['num_events']
-    assert stop_doc['num_events']['primary'] == 1
+    assert stop_doc['num_events']['primary'] == 3
 
 
 def test_round_trip_pagination():


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes errors in schemas discovered working at ALS

<!--- Describe your changes in detail -->

 - properly use `$ref`
 - fix typo in which schema validates datum docs
 - fix bug in updating the total number of events
 - adds smoke tests

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The generate_datum_page and generate_event_page code did not work

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Adds a smoke test the exercises both functions

<!--
-->