### PR TITLE
Add option for RunRouter to fill documents.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,10 @@
 [flake8]
-exclude = .git,__pycache__,build,dist,versioneer.py,event_model/_version.py,docs/source/conf.py
+exclude =
+    .git,
+    __pycache__,
+    build,
+    dist,
+    versioneer.py,
+    event_model/_version.py,
+    docs/source/conf.py
+max-line-length = 115

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -493,9 +493,6 @@ class Filler(DocumentRouter):
     def inplace(self):
         return self._inplace
 
-    def start(self, doc):
-        return doc
-
     def resource(self, doc):
         # Defer creating the handler instance until we actually need it, when
         # we fill the first Event field that requires this Resource.
@@ -644,9 +641,6 @@ class Filler(DocumentRouter):
 
     def descriptor(self, doc):
         self._descriptor_cache[doc['uid']] = doc
-        return doc
-
-    def stop(self, doc):
         return doc
 
     def __enter__(self):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -494,6 +494,42 @@ class RunRouter(DocumentRouter):
         as they arrive. They must return one list, which may be empty,
         containing callbacks that will receive all Events that reference that
         EventDescriptor and finally the RunStop document for the run.
+    handler_registry : dict, optional
+        This is passed to the Filler or whatever class is given in the
+        filler_class parametr below.
+
+        Maps each 'spec' (a string identifying a given type or external
+        resource) to a handler class.
+
+        A 'handler class' may be any callable with the signature::
+
+            handler_class(resource_path, root, **resource_kwargs)
+
+        It is expected to return an object, a 'handler instance', which is also
+        callable and has the following signature::
+
+            handler_instance(**datum_kwargs)
+
+        As the names 'handler class' and 'handler instance' suggest, this is
+        typically implemented using a class that implements ``__init__`` and
+        ``__call__``, with the respective signatures. But in general it may be
+        any callable-that-returns-a-callable.
+    root_map: dict, optional
+        This is passed to Filler or whatever class is given in the filler_class
+        parameter below.
+
+        str -> str mapping to account for temporarily moved/copied/remounted
+        files.  Any resources which have a ``root`` in ``root_map`` will be
+        loaded using the mapped ``root``.
+    filler_class: type
+        This is Filler by default. It can be a Filler subclass,
+        ``functools.partial(Filler, ...)``, or any class that provides the same
+        methods as ``DocumentRouter``.
+    fill_or_fail: boolean, optional
+        By default (False), if a document with a spec not in
+        ``handler_registery`` is encountered, let it pass through unfilled. But
+        if set to True, fill everything and `raise
+        ``UndefinedAssetSpecification`` if some unknown spec is encountered.
     """
     def __init__(self, factories, handler_registry=None, *,
                  root_map=None, filler_class=Filler, fill_or_fail=False):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -128,215 +128,6 @@ class DocumentRouter:
         self.datum_page(bulk_datum_to_datum_page(doc))
 
 
-class RunRouter(DocumentRouter):
-    """
-    Routes documents, by run, to callbacks it creates from factory functions.
-
-    A RunRouter is callable, and it has the signature ``router(name, doc)``,
-    suitable for subscribing to the RunEngine.
-
-    It is configured with a list of factory functions that produce callbacks in
-    a two-layered scheme, described below.
-
-    .. warning::
-
-       This is experimental. In a future release, it may be changed in a
-       backward-incompatible way or fully removed.
-
-    Parameters
-    ----------
-    factories : list
-        A list of callables with the signature::
-
-            factory('start', start_doc) -> List[Callbacks], List[SubFactories]
-
-        which should return two lists, which may be empty. All items in the
-        first list should be callbacks --- callables with the signature::
-
-            callback(name, doc)
-
-        that will receive all subsequent documents from the run including the
-        RunStop document. All items in the second list should be "subfactories"
-        with the signature::
-
-            subfactory('descriptor', descriptor_doc) -> List[Callbacks]
-
-        These will receive each of the EventDescriptor documents for the run,
-        as they arrive. They must return one list, which may be empty,
-        containing callbacks that will receive all Events that reference that
-        EventDescriptor and finally the RunStop document for the run.
-    """
-    def __init__(self, factories, handler_registry=None, *,
-                 root_map=None, filler_class=Filler, fill_or_fail=False):
-        self.factories = factories
-        self.handler_registry = handler_registry or {}
-        self.filler_class = filler_class
-        self.fill_or_fail = fill_or_fail
-        self.root_map = root_map
-
-        # Map RunStart UID to "subfactory" functions that want all
-        # EventDescriptors from that run.
-        self._subfactories = defaultdict(list)
-
-        # Callbacks that want all the documents from a given run, keyed on
-        # RunStart UID.
-        self._factory_cbs_by_start = defaultdict(list)
-
-        # Callbacks that want all the documents from a given run, keyed on
-        # each EventDescriptor UID in the run.
-        self._factory_cbs_by_descriptor = defaultdict(list)
-
-        # Callbacks that want documents related to a given EventDescriptor,
-        # keyed on EventDescriptor UID.
-        self._subfactory_cbs_by_descriptor = defaultdict(list)
-
-        # Callbacks that want documents related to a given EventDescriptor,
-        # keyed on the RunStart UID referenced by that EventDescriptor.
-        self._subfactory_cbs_by_start = defaultdict(list)
-
-        # Map RunStart UID to the list EventDescriptor. This is used to
-        # facilitate efficient cleanup of the caches above.
-        self._descriptors = defaultdict(list)
-
-        # Map EventDescriptor UID to RunStart UID. This is used for looking up
-        # Fillers.
-        self._descriptor_to_start = {}
-
-        # Map Resource UID to RunStart UID.
-        self._resources = {}
-
-        # Old-style Resources that do not have a RunStart UID
-        self._unlabeled_resources = deque(maxlen=10000)
-
-        # Map Runstart UID to instances of self.filler_class.
-        self._fillers = {}
-
-    def __repr__(self):
-        return (f"RunRouter([\n" +
-                f"\n".join(f"    {factory}" for factory in self.factories) +
-                f"])")
-
-    def start(self, doc):
-        uid = doc['uid']
-        filler = self.filler_class(self.handler_registry,
-                                   root_map=self.root_map,
-                                   inplace=False)
-        self._fillers[uid] = filler
-        # No need to pass the document to filler
-        # because Fillers do nothing with 'start'.
-        for factory in self.factories:
-            callbacks, subfactories = factory('start', doc)
-            self._factory_cbs_by_start[uid].extend(callbacks)
-            self._subfactories[uid].extend(subfactories)
-
-    def descriptor(self, doc):
-        uid = doc['uid']
-        start_uid = doc['run_start']
-        self._fillers[start_uid].descriptor(doc)
-        # Apply all factory cbs for this run to this descriptor, and run them.
-        factory_cbs = self._factory_cbs_by_start[start_uid]
-        self._factory_cbs_by_descriptor[uid].extend(factory_cbs)
-        for callback in factory_cbs:
-            callback('descriptor', doc)
-        # Let all the subfactories add any relavant callbacks.
-        for subfactory in self._subfactories[start_uid]:
-            callbacks = subfactory('descriptor', doc)
-            self._subfactory_cbs_by_start[start_uid].extend(callbacks)
-            self._subfactory_cbs_by_descriptor[uid].extend(callbacks)
-        # Keep track of the RunStart UID -> [EventDescriptor UIDs] mapping for
-        # purposes of cleanup in stop().
-        self._descriptors[start_uid].append(uid)
-        # Keep track of the EventDescriptor UID -> RunStartUID for filling
-        # purposes.
-        self._descriptor_to_start[uid] = start_uid
-
-    def event_page(self, doc):
-        descriptor_uid = doc['descriptor']
-        start_uid = self._descriptor_to_start[descriptor_uid]
-        try:
-            doc = self._fillers[start_uid].event_page(doc)
-        except UndefinedAssetSpecification:
-            if self.fill_or_fail:
-                raise
-        for callback in self._factory_cbs_by_descriptor[descriptor_uid]:
-            callback('event_page', doc)
-        for callback in self._subfactory_cbs_by_descriptor[descriptor_uid]:
-            callback('event_page', doc)
-
-    def datum_page(self, doc):
-        resource_uid = doc['resource']
-        try:
-            start_uid = self._resources[resource_uid]
-        except KeyError:
-            if resource_uid not in self._unlabeled_resources:
-                raise UnresolvableForeignKeyError(
-                    resource_uid,
-                    f"Datum with id {datum_id} refers to unknown Resource "
-                    f"uid {resource_uid}") from err
-            # Old Resources do not have a reference to a RunStart document,
-            # so in turn we cannot immediately tell which run these datum
-            # documents belong to.
-            # Fan them out to every run currently flowing through RunRouter. If
-            # they are not applicable they will do no harm, and this is
-            # expected to be an increasingly rare case.
-            for callbacks in self._factory_cbs_by_start.values():
-                for callback in callbacks:
-                    callback('datum_page', doc)
-            for callbacks in self._subfactory_cbs_by_start.values():
-                for callback in callbacks:
-                    callback('datum_page', doc)
-            for filler in self._fillers.values():
-                filler.datum_page(doc)
-        else:
-            self._fillers[start_uid].datum_page(doc)
-            for callback in self._factory_cbs_by_start[start_uid]:
-                callback('datum_page', doc)
-            for callback in self._subfactory_cbs_by_start[start_uid]:
-                callback('datum_page', doc)
-
-    def resource(self, doc):
-        try:
-            start_uid = doc['run_start']
-        except KeyError:
-            # Old Resources do not have a reference to a RunStart document.
-            # Fan them out to every run currently flowing through RunRouter. If
-            # they are not applicable they will do no harm, and this is
-            # expected to be an increasingly rare case.
-            self._unlabeled_resources.append(doc['uid'])
-            for callbacks in self._factory_cbs_by_start.values():
-                for callback in callbacks:
-                    callback('resource', doc)
-            for callbacks in self._subfactory_cbs_by_start.values():
-                for callback in callbacks:
-                    callback('resource', doc)
-            for filler in self._fillers.values():
-                filler.resource(doc)
-        else:
-            self._fillers[start_uid].resource(doc)
-            self._resources[doc['uid']] = doc['run_start']
-            for callback in self._factory_cbs_by_start[start_uid]:
-                callback('resource', doc)
-            for callback in self._subfactory_cbs_by_start[start_uid]:
-                callback('resource', doc)
-
-    def stop(self, doc):
-        start_uid = doc['run_start']
-        for callback in self._factory_cbs_by_start[start_uid]:
-            callback('stop', doc)
-        for callback in self._subfactory_cbs_by_start[start_uid]:
-            callback('stop', doc)
-        # Clean up references.
-        self._fillers.pop(start_uid, None)
-        self._subfactories.pop(start_uid, None)
-        self._factory_cbs_by_start.pop(start_uid, None)
-        self._subfactory_cbs_by_start.pop(start_uid, None)
-        for descriptor_uid in self._descriptors.pop(start_uid, ()):
-            self._descriptor_to_start.pop(descriptor_uid, None)
-            self._factory_cbs_by_descriptor.pop(descriptor_uid, None)
-            self._subfactory_cbs_by_descriptor.pop(descriptor_uid, None)
-        self._resources.pop(start_uid, None)
-
-
 class Filler(DocumentRouter):
     """Pass documents through, loading any externally-referenced data.
 
@@ -664,6 +455,215 @@ class Filler(DocumentRouter):
             raise EventModelRuntimeError(
                 "This Filler has been closed and is no longer usable.")
         return super().__call__(name, doc, validate)
+
+
+class RunRouter(DocumentRouter):
+    """
+    Routes documents, by run, to callbacks it creates from factory functions.
+
+    A RunRouter is callable, and it has the signature ``router(name, doc)``,
+    suitable for subscribing to the RunEngine.
+
+    It is configured with a list of factory functions that produce callbacks in
+    a two-layered scheme, described below.
+
+    .. warning::
+
+       This is experimental. In a future release, it may be changed in a
+       backward-incompatible way or fully removed.
+
+    Parameters
+    ----------
+    factories : list
+        A list of callables with the signature::
+
+            factory('start', start_doc) -> List[Callbacks], List[SubFactories]
+
+        which should return two lists, which may be empty. All items in the
+        first list should be callbacks --- callables with the signature::
+
+            callback(name, doc)
+
+        that will receive all subsequent documents from the run including the
+        RunStop document. All items in the second list should be "subfactories"
+        with the signature::
+
+            subfactory('descriptor', descriptor_doc) -> List[Callbacks]
+
+        These will receive each of the EventDescriptor documents for the run,
+        as they arrive. They must return one list, which may be empty,
+        containing callbacks that will receive all Events that reference that
+        EventDescriptor and finally the RunStop document for the run.
+    """
+    def __init__(self, factories, handler_registry=None, *,
+                 root_map=None, filler_class=Filler, fill_or_fail=False):
+        self.factories = factories
+        self.handler_registry = handler_registry or {}
+        self.filler_class = filler_class
+        self.fill_or_fail = fill_or_fail
+        self.root_map = root_map
+
+        # Map RunStart UID to "subfactory" functions that want all
+        # EventDescriptors from that run.
+        self._subfactories = defaultdict(list)
+
+        # Callbacks that want all the documents from a given run, keyed on
+        # RunStart UID.
+        self._factory_cbs_by_start = defaultdict(list)
+
+        # Callbacks that want all the documents from a given run, keyed on
+        # each EventDescriptor UID in the run.
+        self._factory_cbs_by_descriptor = defaultdict(list)
+
+        # Callbacks that want documents related to a given EventDescriptor,
+        # keyed on EventDescriptor UID.
+        self._subfactory_cbs_by_descriptor = defaultdict(list)
+
+        # Callbacks that want documents related to a given EventDescriptor,
+        # keyed on the RunStart UID referenced by that EventDescriptor.
+        self._subfactory_cbs_by_start = defaultdict(list)
+
+        # Map RunStart UID to the list EventDescriptor. This is used to
+        # facilitate efficient cleanup of the caches above.
+        self._descriptors = defaultdict(list)
+
+        # Map EventDescriptor UID to RunStart UID. This is used for looking up
+        # Fillers.
+        self._descriptor_to_start = {}
+
+        # Map Resource UID to RunStart UID.
+        self._resources = {}
+
+        # Old-style Resources that do not have a RunStart UID
+        self._unlabeled_resources = deque(maxlen=10000)
+
+        # Map Runstart UID to instances of self.filler_class.
+        self._fillers = {}
+
+    def __repr__(self):
+        return (f"RunRouter([\n" +
+                f"\n".join(f"    {factory}" for factory in self.factories) +
+                f"])")
+
+    def start(self, doc):
+        uid = doc['uid']
+        filler = self.filler_class(self.handler_registry,
+                                   root_map=self.root_map,
+                                   inplace=False)
+        self._fillers[uid] = filler
+        # No need to pass the document to filler
+        # because Fillers do nothing with 'start'.
+        for factory in self.factories:
+            callbacks, subfactories = factory('start', doc)
+            self._factory_cbs_by_start[uid].extend(callbacks)
+            self._subfactories[uid].extend(subfactories)
+
+    def descriptor(self, doc):
+        uid = doc['uid']
+        start_uid = doc['run_start']
+        self._fillers[start_uid].descriptor(doc)
+        # Apply all factory cbs for this run to this descriptor, and run them.
+        factory_cbs = self._factory_cbs_by_start[start_uid]
+        self._factory_cbs_by_descriptor[uid].extend(factory_cbs)
+        for callback in factory_cbs:
+            callback('descriptor', doc)
+        # Let all the subfactories add any relavant callbacks.
+        for subfactory in self._subfactories[start_uid]:
+            callbacks = subfactory('descriptor', doc)
+            self._subfactory_cbs_by_start[start_uid].extend(callbacks)
+            self._subfactory_cbs_by_descriptor[uid].extend(callbacks)
+        # Keep track of the RunStart UID -> [EventDescriptor UIDs] mapping for
+        # purposes of cleanup in stop().
+        self._descriptors[start_uid].append(uid)
+        # Keep track of the EventDescriptor UID -> RunStartUID for filling
+        # purposes.
+        self._descriptor_to_start[uid] = start_uid
+
+    def event_page(self, doc):
+        descriptor_uid = doc['descriptor']
+        start_uid = self._descriptor_to_start[descriptor_uid]
+        try:
+            doc = self._fillers[start_uid].event_page(doc)
+        except UndefinedAssetSpecification:
+            if self.fill_or_fail:
+                raise
+        for callback in self._factory_cbs_by_descriptor[descriptor_uid]:
+            callback('event_page', doc)
+        for callback in self._subfactory_cbs_by_descriptor[descriptor_uid]:
+            callback('event_page', doc)
+
+    def datum_page(self, doc):
+        resource_uid = doc['resource']
+        try:
+            start_uid = self._resources[resource_uid]
+        except KeyError:
+            if resource_uid not in self._unlabeled_resources:
+                raise UnresolvableForeignKeyError(
+                    resource_uid,
+                    f"Datum with id {datum_id} refers to unknown Resource "
+                    f"uid {resource_uid}") from err
+            # Old Resources do not have a reference to a RunStart document,
+            # so in turn we cannot immediately tell which run these datum
+            # documents belong to.
+            # Fan them out to every run currently flowing through RunRouter. If
+            # they are not applicable they will do no harm, and this is
+            # expected to be an increasingly rare case.
+            for callbacks in self._factory_cbs_by_start.values():
+                for callback in callbacks:
+                    callback('datum_page', doc)
+            for callbacks in self._subfactory_cbs_by_start.values():
+                for callback in callbacks:
+                    callback('datum_page', doc)
+            for filler in self._fillers.values():
+                filler.datum_page(doc)
+        else:
+            self._fillers[start_uid].datum_page(doc)
+            for callback in self._factory_cbs_by_start[start_uid]:
+                callback('datum_page', doc)
+            for callback in self._subfactory_cbs_by_start[start_uid]:
+                callback('datum_page', doc)
+
+    def resource(self, doc):
+        try:
+            start_uid = doc['run_start']
+        except KeyError:
+            # Old Resources do not have a reference to a RunStart document.
+            # Fan them out to every run currently flowing through RunRouter. If
+            # they are not applicable they will do no harm, and this is
+            # expected to be an increasingly rare case.
+            self._unlabeled_resources.append(doc['uid'])
+            for callbacks in self._factory_cbs_by_start.values():
+                for callback in callbacks:
+                    callback('resource', doc)
+            for callbacks in self._subfactory_cbs_by_start.values():
+                for callback in callbacks:
+                    callback('resource', doc)
+            for filler in self._fillers.values():
+                filler.resource(doc)
+        else:
+            self._fillers[start_uid].resource(doc)
+            self._resources[doc['uid']] = doc['run_start']
+            for callback in self._factory_cbs_by_start[start_uid]:
+                callback('resource', doc)
+            for callback in self._subfactory_cbs_by_start[start_uid]:
+                callback('resource', doc)
+
+    def stop(self, doc):
+        start_uid = doc['run_start']
+        for callback in self._factory_cbs_by_start[start_uid]:
+            callback('stop', doc)
+        for callback in self._subfactory_cbs_by_start[start_uid]:
+            callback('stop', doc)
+        # Clean up references.
+        self._fillers.pop(start_uid, None)
+        self._subfactories.pop(start_uid, None)
+        self._factory_cbs_by_start.pop(start_uid, None)
+        self._subfactory_cbs_by_start.pop(start_uid, None)
+        for descriptor_uid in self._descriptors.pop(start_uid, ()):
+            self._descriptor_to_start.pop(descriptor_uid, None)
+            self._factory_cbs_by_descriptor.pop(descriptor_uid, None)
+            self._subfactory_cbs_by_descriptor.pop(descriptor_uid, None)
+        self._resources.pop(start_uid, None)
 
 
 class EventModelError(Exception):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -636,8 +636,7 @@ class RunRouter(DocumentRouter):
             if resource_uid not in self._unlabeled_resources:
                 raise UnresolvableForeignKeyError(
                     resource_uid,
-                    f"Datum with id {datum_id} refers to unknown Resource "
-                    f"uid {resource_uid}") from err
+                    f"DatumPage refers to unknown Resource uid {resource_uid}")
             # Old Resources do not have a reference to a RunStart document,
             # so in turn we cannot immediately tell which run these datum
             # documents belong to.

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -579,7 +579,7 @@ def test_rechunk_datum_pages():
     assert datum_pages == list(datum_pages_13)
 
 
-def test_run_router():
+def test_run_router(tmp_path):
     bundle = event_model.compose_run()
     docs = []
     start_doc, compose_descriptor, compose_resource, compose_stop = bundle
@@ -597,7 +597,7 @@ def test_run_router():
     baseline_descriptor_doc, compose_baseline_event, compose_event_page = bundle
     docs.append(('descriptor', baseline_descriptor_doc))
     bundle = compose_resource(
-        spec='TIFF', root='/tmp', resource_path='stack.tiff',
+        spec='TIFF', root=str(tmp_path), resource_path='stack.tiff',
         resource_kwargs={})
     resource_doc, compose_datum, compose_datum_page = bundle
     docs.append(('resource', resource_doc))
@@ -668,3 +668,58 @@ def test_run_router():
     assert expected_item in collected
     assert unexpected_item not in collected
     collected.clear()
+
+    # Test RunRouter with handler_registry.
+
+    class FakeTiffHandler:
+        def __init__(self, resource_path):
+            assert resource_path == str(tmp_path / "stack.tiff")
+
+        def __call__(self, slice):
+            return numpy.ones((5, 5))
+
+    reg = {'TIFF': FakeTiffHandler}
+
+    def check_filled(name, doc):
+        if name == 'event_page':
+            for is_filled in doc['filled'].values():
+                assert all(is_filled)
+        elif name == 'event':
+            for is_filled in doc['filled'].values():
+                assert is_filled
+
+    def check_not_filled(name, doc):
+        if name == 'event_page':
+            for is_filled in doc['filled'].values():
+                assert not any(is_filled)
+        elif name == 'event':
+            for is_filled in doc['filled'].values():
+                assert not is_filled
+
+    def check_filled_factory(name, doc):
+        return [check_filled], []
+
+    def check_not_filled_factory(name, doc):
+        return [check_not_filled], []
+
+    # If reg is missing our spec (or just not given) docs pass through
+    # unfilled.
+    rr = event_model.RunRouter([check_not_filled_factory])
+    for name, doc in docs:
+        rr(name, doc)
+
+    # If fill_or_fail is set to True and reg is missing our spec (or just not
+    # given) we raise.
+    rr = event_model.RunRouter([check_not_filled_factory], fill_or_fail=True)
+    with pytest.raises(event_model.UndefinedAssetSpecification):
+        for name, doc in docs:
+            rr(name, doc)
+
+    # If spec is provided, docs are filled, regardless of fill_or_fail.
+    rr = event_model.RunRouter([check_filled_factory], reg)
+    for name, doc in docs:
+        rr(name, doc)
+
+    rr = event_model.RunRouter([check_filled_factory], reg, fill_or_fail=True)
+    for name, doc in docs:
+        rr(name, doc)


### PR DESCRIPTION
In several instances (various demos and some beamlines) we have worked
out contorted code to handle the pattern:

```
RunEngine ---> (maybe 0MQ...) --> Filler ---> suitcase
```

where the consumer could be a suitcase or really anyconsumer that
requires filled data, like a live image viewer. There is currently no
elegant way to do this because `Filler` is a sink: there is no way to
"subscribe" to it.

One possible solution is to add `Filler.subscribe`, but another, which
is better for resource management and also simpler for users, is to put
`RunRouter` in charge of creating and destroying `Filler` instances.
That's what this PR does.

Notice that it provides hooks to:

* Just provide a `handler_registry` (the simple, common case)
* Decide whether to fill only certain specs---ones that aren't in the
  registry will be ignored by default
* Customize the type of Filler (e.g. could be a `DaskFiller`)
* Provide custom caches to Filler via passing in `filler_class=functools.partial(Filler ...)`

This was worked out in conversation with @tacaswell.

This needs tests.