### PR TITLE
If Resource root was change, note that.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -556,8 +556,8 @@ class Filler(DocumentRouter):
                 f"handler registry.") from err
         # Apply root_map.
         resource_path = resource['resource_path']
-        root = resource.get('root', '')
-        root = self.root_map.get(root, root)
+        original_root = resource.get('root', '')
+        root = self.root_map.get(original_root, original_root)
         if root:
             resource_path = os.path.join(root, resource_path)
         try:
@@ -566,10 +566,13 @@ class Filler(DocumentRouter):
         except Exception as err:
             msg = (f"Error instantiating handler "
                    f"class {handler_class} "
-                   f"with Resource document {resource}.")
-            if root != resouce.get('root', ''):
-                msg += (f" Note that its 'root' field was "
-                        f"mapped to {root} by root_map.")
+                   f"with Resource document {resource}. ")
+            if root != original_root:
+                msg += (f"It 'root' field was "
+                        f"mapped from {original_root} to {root} by root_map.")
+            else:
+                msg += (f"Its 'root' field {original_root} was "
+                        f"*not* modified by root_map.")
             raise EventModelError(msg) from err
         return handler
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -568,7 +568,7 @@ class Filler(DocumentRouter):
                    f"class {handler_class} "
                    f"with Resource document {resource}. ")
             if root != original_root:
-                msg += (f"It 'root' field was "
+                msg += (f"Its 'root' field was "
                         f"mapped from {original_root} to {root} by root_map.")
             else:
                 msg += (f"Its 'root' field {original_root} was "

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -564,10 +564,13 @@ class Filler(DocumentRouter):
             handler = handler_class(resource_path,
                                     **resource['resource_kwargs'])
         except Exception as err:
-            raise EventModelError(
-                f"Error instantiating handler "
-                f"class {handler_class} "
-                f"with Resource document {resource}.") from err
+            msg = (f"Error instantiating handler "
+                   f"class {handler_class} "
+                   f"with Resource document {resource}.")
+            if root != resouce.get('root', ''):
+                msg += (f" Note that its 'root' field was "
+                        f"mapped to {root} by root_map.")
+            raise EventModelError(msg) from err
         return handler
 
     def _get_handler_maybe_cached(self, resource):


### PR DESCRIPTION
If handler creation fails because a file is not found,
the error message can be confusing because it shows the Resource
document but does not include any information about whether the
'root' was overridden by ``root_map``.

The phrasing here could probably be improved upon. Any ideas?