### PR TITLE
FIX: special case dask.array.Array in NumpyEnocder

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1648,6 +1648,12 @@ class NumpyEncoder(json.JSONEncoder):
     """
     # Credit: https://stackoverflow.com/a/47626762/1221924
     def default(self, obj):
+        try:
+            import dask.array
+            if isinstance(obj, dask.array.Array):
+                obj = numpy.asarray(obj)
+        except ImportError:
+            pass
         if isinstance(obj, (numpy.generic, numpy.ndarray)):
             if numpy.isscalar(obj):
                 return obj.item()


### PR DESCRIPTION
This is not elegant, but it works

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extend the type checking we do in our numpy encoder for json
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes a test failure in databroker where we get events with `dask.array.Array` in it

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The databroker test suit failures are fixed.

<!--
## Screenshots (if appropriate):
-->
