### PR TITLE
clone() should respect inplace of parent

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -432,6 +432,8 @@ class Filler(DocumentRouter):
             root_map = self.root_map
         if coerce is None:
             coerce = self._coerce
+        if inplace is None:
+            inplace = self.inplace
         if retry_intervals is None:
             retry_intervals = self.retry_intervals
         return Filler(handler_registry, root_map=root_map,


### PR DESCRIPTION
This was simply missed in the implementation of ``clone`` and resulted
in a warning that breaks the databroker documentation build.