### PR TITLE
Allow DocRouter subclass to define page or non-page.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -97,8 +97,6 @@ class DocumentRouter:
                 # DatumPage or None or NotImplemented.
                 output_datum_page = self.datum_page(datum_page) or datum_page
                 if output_datum_page is not NotImplemented:
-                    if output_datum_page is None:
-                        output_datum_page = doc
                     output_doc, = unpack_datum_page(output_datum_page)
             elif name == 'event_page':
                 output_events = []

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -81,8 +81,8 @@ class DocumentRouter:
         """
         output_doc = getattr(self, name)(doc)
 
-        # If 'event' is not defined by the subclass by 'event_page' is, or vice
-        # versa, use that. And the same for 'datum_page' / 'datum.
+        # If 'event' is not defined by the subclass but 'event_page' is, or
+        # vice versa, use that. And the same for 'datum_page' / 'datum.
         if output_doc is NotImplemented:
             if name == 'event':
                 event_page = pack_event_page(doc)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -93,7 +93,7 @@ class DocumentRouter:
                     output_doc, = unpack_event_page(output_event_page)
             elif name == 'datum':
                 datum_page = pack_datum_page(doc)
-                # Subclass' implementation of event_page may return a valid
+                # Subclass' implementation of datum_page may return a valid
                 # DatumPage or None or NotImplemented.
                 output_datum_page = self.datum_page(datum_page) or datum_page
                 if output_datum_page is not NotImplemented:
@@ -103,7 +103,7 @@ class DocumentRouter:
             elif name == 'event_page':
                 output_events = []
                 for event in unpack_event_page(doc):
-                    # Subclass' implementation of event_page may return a valid
+                    # Subclass' implementation of event may return a valid
                     # Event or None or NotImplemented.
                     output_event = self.event(event) or event
                     if output_event is NotImplemented:
@@ -114,7 +114,7 @@ class DocumentRouter:
             elif name == 'datum_page':
                 output_datums = []
                 for datum in unpack_datum_page(doc):
-                    # Subclass' implementation of event_page may return a valid
+                    # Subclass' implementation of datum may return a valid
                     # Datum or None or NotImplemented.
                     output_datum = self.datum(datum) or datum
                     if output_datums is NotImplemented:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -80,47 +80,73 @@ class DocumentRouter:
         Optionally validate that the result is still a valid document.
         """
         output_doc = getattr(self, name)(doc)
+
+        # If 'event' is not defined by the subclass by 'event_page' is, or vice
+        # versa, use that. And the same for 'datum_page' / 'datum.
+        if output_doc is NotImplemented:
+            if name == 'event':
+                event_page = pack_event_page(doc)
+                output_event_page = self.event_page(event_page) or event_page
+                # Subclass' implementation of event_page may return a valid EventPage
+                # or None.
+                if output_event_page is not NotImplemented:
+                    output_doc, = unpack_event_page(output_event_page)
+            elif name == 'datum':
+                datum_page = pack_datum_page(doc)
+                output_datum_page = self.datum_page(datum_page) or datum_page
+                # Subclass' implementation of event_page may return a valid DatumPage
+                # or None.
+                if output_datum_page is not NotImplemented:
+                    if output_datum_page is None:
+                        output_datum_page = doc
+                    output_doc, = unpack_datum_page(output_datum_page)
+            elif name == 'event_page':
+                output_events = []
+                for event in unpack_event_page(doc):
+                    output_event = self.event(event) or event
+                    if output_event is NotImplemented:
+                        break
+                    output_events.append(output_event)
+                output_doc = pack_event_page(*output_events)
+            elif name == 'datum_page':
+                output_datums = []
+                for datum in unpack_datum_page(doc):
+                    output_datum = self.datum(datum) or datum
+                    if output_datums is NotImplemented:
+                        break
+                    output_datums.append(output_datum)
+                output_doc = pack_datum_page(*output_datums)
+        # If we still don't find an implemented method by here, then pass the
+        # original document through.
+        if output_doc is NotImplemented:
+            output_doc = doc
         if validate:
             schema_validators[getattr(DocumentNames, name)].validate(output_doc)
         return (name, output_doc if output_doc is not None else doc)
 
     def start(self, doc):
-        return doc
+        return NotImplemented
 
     def stop(self, doc):
-        return doc
+        return NotImplemented
 
     def descriptor(self, doc):
-        return doc
+        return NotImplemented
 
     def resource(self, doc):
-        return doc
+        return NotImplemented
 
     def event(self, doc):
-        event_page = pack_event_page(doc)
-        output_event_page = self.event_page(event_page)
-        # Subclass' implementation of event_page may return a valid EventPage
-        # or None.
-        if output_event_page is None:
-            return None
-        output_event, = unpack_event_page(output_event_page)
-        return output_event
+        return NotImplemented
 
     def datum(self, doc):
-        datum_page = pack_datum_page(doc)
-        output_datum_page = self.datum_page(datum_page)
-        # Subclass' implementation of event_page may return a valid DatumPage
-        # or None.
-        if output_datum_page is None:
-            return None
-        output_datum, = unpack_datum_page(output_datum_page)
-        return output_datum
+        return NotImplemented
 
     def event_page(self, doc):
-        return doc
+        return NotImplemented
 
     def datum_page(self, doc):
-        return doc
+        return NotImplemented
 
     def bulk_events(self, doc):
         # Do not modify this in a subclass. Use event_page.

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -86,16 +86,16 @@ class DocumentRouter:
         if output_doc is NotImplemented:
             if name == 'event':
                 event_page = pack_event_page(doc)
+                # Subclass' implementation of event_page may return a valid
+                # EventPage or None or NotImplemented.
                 output_event_page = self.event_page(event_page) or event_page
-                # Subclass' implementation of event_page may return a valid EventPage
-                # or None.
                 if output_event_page is not NotImplemented:
                     output_doc, = unpack_event_page(output_event_page)
             elif name == 'datum':
                 datum_page = pack_datum_page(doc)
+                # Subclass' implementation of event_page may return a valid
+                # DatumPage or None or NotImplemented.
                 output_datum_page = self.datum_page(datum_page) or datum_page
-                # Subclass' implementation of event_page may return a valid DatumPage
-                # or None.
                 if output_datum_page is not NotImplemented:
                     if output_datum_page is None:
                         output_datum_page = doc
@@ -103,19 +103,25 @@ class DocumentRouter:
             elif name == 'event_page':
                 output_events = []
                 for event in unpack_event_page(doc):
+                    # Subclass' implementation of event_page may return a valid
+                    # Event or None or NotImplemented.
                     output_event = self.event(event) or event
                     if output_event is NotImplemented:
                         break
                     output_events.append(output_event)
-                output_doc = pack_event_page(*output_events)
+                else:
+                    output_doc = pack_event_page(*output_events)
             elif name == 'datum_page':
                 output_datums = []
                 for datum in unpack_datum_page(doc):
+                    # Subclass' implementation of event_page may return a valid
+                    # Datum or None or NotImplemented.
                     output_datum = self.datum(datum) or datum
                     if output_datums is NotImplemented:
                         break
                     output_datums.append(output_datum)
-                output_doc = pack_datum_page(*output_datums)
+                else:
+                    output_doc = pack_datum_page(*output_datums)
         # If we still don't find an implemented method by here, then pass the
         # original document through.
         if output_doc is NotImplemented:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -342,7 +342,8 @@ def test_document_router_with_validation():
 
 def test_document_router_dispatch_event():
 
-    mutable = []  # used for counting calls
+    event_calls = []  # used for counting calls
+    event_page_calls = []  # used for counting calls
 
     # example documents
     event1 = {'data': {'x': 1},
@@ -364,62 +365,83 @@ def test_document_router_dispatch_event():
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['data']['x'] == doc['seq_num']
-            mutable.append(object())
+            event_calls.append(object())
+
+        def event_page(self, doc):
+            event_page_calls.append(object())
+            return super().event_page(doc)
 
     dr = DefinesEventNotEventPage()
     # Test that Event is routed to Event.
     dr('event', event1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(event_calls) == 1
+    assert len(event_page_calls) == 0
+    event_calls.clear()
+    event_page_calls.clear()
     # Test that EventPage is unpacked and routed to Event one at a time.
     dr('event_page', event_page)
-    assert len(mutable) == 2
-    mutable.clear()
+    assert len(event_page_calls) == 1
+    assert len(event_calls) == 2
+    event_calls.clear()
+    event_page_calls.clear()
 
     class DefinesEventPageNotEvent(event_model.DocumentRouter):
+        def event(self, doc):
+            event_calls.append(object())
+            return super().event(doc)
+
         def event_page(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['data']['x'][0] == 1
-            mutable.append(object())
+            event_page_calls.append(object())
 
     dr = DefinesEventPageNotEvent()
     # Test that Event is packed and routed to EventPage.
     dr('event', event1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(event_calls) == 1
+    assert len(event_page_calls) == 1
+    event_calls.clear()
+    event_page_calls.clear()
     # Test that EventPage is routed to EventPage.
     dr('event_page', event_page)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(event_page_calls) == 1
+    assert len(event_calls) == 0
+    event_calls.clear()
+    event_page_calls.clear()
 
     class DefinesEventPageAndEvent(event_model.DocumentRouter):
         def event(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['data']['x'] == doc['seq_num']
-            mutable.append(object())
+            event_calls.append(object())
 
         def event_page(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['data']['x'][0] == 1
-            mutable.append(object())
+            event_page_calls.append(object())
 
     dr = DefinesEventPageAndEvent()
     # Test that Event is routed to Event.
     dr('event', event1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(event_calls) == 1
+    assert len(event_page_calls) == 0
+    event_calls.clear()
+    event_page_calls.clear()
     # Test that EventPage is routed to EventPage.
     dr('event_page', event_page)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(event_page_calls) == 1
+    assert len(event_calls) == 0
+    event_calls.clear()
+    event_page_calls.clear()
 
 
 def test_document_router_dispatch_datum():
 
-    mutable = []  # used for counting calls
+    datum_calls = []  # used for counting calls
+    datum_page_calls = []  # used for counting calls
 
     # example documents
     datum1 = {'datum_id': 'placeholder/1',
@@ -435,57 +457,78 @@ def test_document_router_dispatch_datum():
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['datum_kwargs']['index'] == int(doc['datum_id'][-1])
-            mutable.append(object())
+            datum_calls.append(object())
+
+        def datum_page(self, doc):
+            datum_page_calls.append(object())
+            return super().datum_page(doc)
 
     dr = DefinesDatumNotDatumPage()
     # Test that Datum is routed to Datum.
     dr('datum', datum1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(datum_calls) == 1
+    assert len(datum_page_calls) == 0
+    datum_calls.clear()
+    datum_page_calls.clear()
     # Test that DatumPage is unpacked and routed to Datum one at a time.
     dr('datum_page', datum_page)
-    assert len(mutable) == 2
-    mutable.clear()
+    assert len(datum_page_calls) == 1
+    assert len(datum_calls) == 2
+    datum_calls.clear()
+    datum_page_calls.clear()
 
     class DefinesDatumPageNotDatum(event_model.DocumentRouter):
+        def datum(self, doc):
+            datum_calls.append(object())
+            return super().datum_page(doc)
+
         def datum_page(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['datum_kwargs']['index'][0] == int(doc['datum_id'][0][-1])
-            mutable.append(object())
+            datum_page_calls.append(object())
 
     dr = DefinesDatumPageNotDatum()
     # Test that Datum is packed and routed to DatumPage.
     dr('datum', datum1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(datum_calls) == 1
+    assert len(datum_page_calls) == 1
+    datum_calls.clear()
+    datum_page_calls.clear()
     # Test that DatumPage is routed to DatumPage.
     dr('datum_page', datum_page)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(datum_page_calls) == 1
+    assert len(datum_calls) == 0
+    datum_calls.clear()
+    datum_page_calls.clear()
+    # Test that DatumPage is routed to DatumPage.
 
     class DefinesDatumPageAndDatum(event_model.DocumentRouter):
         def datum(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['datum_kwargs']['index'] == int(doc['datum_id'][-1])
-            mutable.append(object())
+            datum_calls.append(object())
 
         def datum_page(self, doc):
             # Just a dumb test that check something particular to these example
             # documents.
             assert doc['datum_kwargs']['index'][0] == int(doc['datum_id'][0][-1])
-            mutable.append(object())
+            datum_page_calls.append(object())
 
     dr = DefinesDatumPageAndDatum()
     # Test that Datum is routed to Datum.
     dr('datum', datum1)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(datum_calls) == 1
+    assert len(datum_page_calls) == 0
+    datum_calls.clear()
+    datum_page_calls.clear()
     # Test that DatumPage is routed to DatumPage.
     dr('datum_page', datum_page)
-    assert len(mutable) == 1
-    mutable.clear()
+    assert len(datum_page_calls) == 1
+    assert len(datum_calls) == 0
+    datum_calls.clear()
+    datum_page_calls.clear()
 
 
 def test_filler(tmp_path):


### PR DESCRIPTION
Currently, `DocumenterRouter` routes any Events it sees to the
`event_page` method, packing them into EventPages along the way. This
means that if someone subclasses `DocumentRouter` and does something
useful the `event_page` method, it will apply to `event` as well,
automatically.

However, the reverse does not work. If a subclass defines `event` but
not `event_page`, any Events will be handled but EventPages will pass
through quietly.

This PR allows a `DocumentRouter` subclass to define `event` *or*
`event_page` and have the documents flow to the one that is defined,
working in the same way that `__add__` and `__radd__` do in Python. As
before, the subclass may define both if it wishes (potentially useful
for performance optimizations) or neither.

This PR needs careful tests.