### PR TITLE
Better error when packing empty page.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1393,7 +1393,7 @@ def pack_datum_page(*datum):
         raise ValueError(
             "The pack_datum_page() function was called with empty *args. "
             "Cannot create an DatumPage from an empty collection of Datum "
-            "because the 'resource' field in an DatumPage cannot be NULL.")
+            "because the 'resource' field in a DatumPage cannot be NULL.")
     datum_id_list = []
     datum_kwarg_list = []
     for datum_ in datum:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1322,7 +1322,10 @@ def pack_event_page(*events):
     event_page : dict
     """
     if not events:
-        raise ValueError("Cannot pack an event_page with no events.")
+        raise ValueError(
+            "The pack_event_page() function was called with empty *args. "
+            "Cannot create an EventPage from an empty collection of Events "
+            "because the 'descriptor' field in an EventPage cannot be NULL.")
     time_list = []
     uid_list = []
     seq_num_list = []
@@ -1387,7 +1390,10 @@ def pack_datum_page(*datum):
     datum_page : dict
     """
     if not datum:
-        raise ValueError("Cannot pack a datum_page with no datum.")
+        raise ValueError(
+            "The pack_datum_page() function was called with empty *args. "
+            "Cannot create an DatumPage from an empty collection of Datum "
+            "because the 'resource' field in an DatumPage cannot be NULL.")
     datum_id_list = []
     datum_kwarg_list = []
     for datum_ in datum:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1321,6 +1321,8 @@ def pack_event_page(*events):
     -------
     event_page : dict
     """
+    if not events:
+        raise ValueError("Cannot pack an event_page with no events.")
     time_list = []
     uid_list = []
     seq_num_list = []
@@ -1384,6 +1386,8 @@ def pack_datum_page(*datum):
     -------
     datum_page : dict
     """
+    if not datum:
+        raise ValueError("Cannot pack a datum_page with no datum.")
     datum_id_list = []
     datum_kwarg_list = []
     for datum_ in datum:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -852,3 +852,10 @@ def test_run_router(tmp_path):
     rr = event_model.RunRouter([check_filled_factory], reg, fill_or_fail=True)
     for name, doc in docs:
         rr(name, doc)
+
+
+def test_pack_empty_raises():
+    with pytest.raises(ValueError):
+        event_model.pack_event_page()
+    with pytest.raises(ValueError):
+        event_model.pack_datum_page()


### PR DESCRIPTION
Currently, calling `pack_event_page()` with no arguments hits an
unexpected code path and thus fails like

```
UnboundLocalError: local variable 'event' referenced before assignment
```

This PR causes it to raise with a more describing `ValueError`. It is
not possible to pack an "empty" Event Page because an Event Page must
have a time and a uid.

The situation in the same for Datum Page, which must have a Resource.
That is also addressed here.

Tests included, should be good to merge.


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->