### PR TITLE
Apply retry logic to handler instantiation.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -688,7 +688,7 @@ def _attempt_with_retries(func, args, kwargs,
 
     func, args, kwargs: self-explanatory
     retry_intervals: list
-        How long to wait (seconds) between before each successive retry.
+        How long to wait (seconds) between each successive retry.
     error_to_catch: Exception class
         If this is raised, retry.
     error_to_raise: Exception instance or class
@@ -703,7 +703,7 @@ def _attempt_with_retries(func, args, kwargs,
         try:
             return func(*args, **kwargs)
         except error_to_catch as error_:
-            # The file may not be visible on the network yet.
+            # The file may not be visible on the filesystem yet.
             # Wait and try again. Stash the error in a variable
             # that we can access later if we run out of attempts.
             error = error_
@@ -711,7 +711,7 @@ def _attempt_with_retries(func, args, kwargs,
             break
     else:
         # We have used up all our attempts. There seems to be an
-        # actual problem. Raise specified from the error stashed above.
+        # actual problem. Raise specified error from the error stashed above.
         raise error_to_raise from error
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -689,6 +689,8 @@ def _attempt_with_retries(func, args, kwargs,
     func, args, kwargs: self-explanatory
     retry_intervals: list
         How long to wait (seconds) between each successive retry.
+        This MUST be an actual list. Since this function is internal we do not
+        take the time to validate or normalize the input.
     error_to_catch: Exception class
         If this is raised, retry.
     error_to_raise: Exception instance or class

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -563,20 +563,23 @@ class Filler(DocumentRouter):
         root = self.root_map.get(original_root, original_root)
         if root:
             resource_path = os.path.join(root, resource_path)
-        try:
-            handler = handler_class(resource_path,
-                                    **resource['resource_kwargs'])
-        except Exception as err:
-            msg = (f"Error instantiating handler "
-                   f"class {handler_class} "
-                   f"with Resource document {resource}. ")
-            if root != original_root:
-                msg += (f"Its 'root' field was "
-                        f"mapped from {original_root} to {root} by root_map.")
-            else:
-                msg += (f"Its 'root' field {original_root} was "
-                        f"*not* modified by root_map.")
-            raise EventModelError(msg) from err
+        msg = (f"Error instantiating handler "
+               f"class {handler_class} "
+               f"with Resource document {resource}. ")
+        if root != original_root:
+            msg += (f"Its 'root' field was "
+                    f"mapped from {original_root} to {root} by root_map.")
+        else:
+            msg += (f"Its 'root' field {original_root} was "
+                    f"*not* modified by root_map.")
+        error_to_raise = EventModelError(msg)
+        handler = _attempt_with_retries(
+            func=handler_class,
+            args=(resource_path,),
+            kwargs=resource['resource_kwargs'],
+            retry_intervals=self.retry_intervals,
+            error_to_catch=IOError,
+            error_to_raise=error_to_raise)
         return handler
 
     def _get_handler_maybe_cached(self, resource):
@@ -632,31 +635,20 @@ class Filler(DocumentRouter):
                         f"Datum with id {datum_id} refers to unknown Resource "
                         f"uid {resource_uid}") from err
                 handler = self._get_handler_maybe_cached(resource)
-                # We are sure to attempt to read that data at least once and
-                # then perhaps additional times depending on the contents of
-                # retry_intervals.
-                error = None
-                for interval in [0] + self.retry_intervals:
-                    ttime.sleep(interval)
-                    try:
-                        payload = handler(**datum_doc['datum_kwargs'])
-                        # Here we are intentionally modifying doc in place.
-                        filled_doc['data'][key] = payload
-                        filled_doc['filled'][key] = datum_id
-                    except IOError as error_:
-                        # The file may not be visible on the network yet.
-                        # Wait and try again. Stash the error in a variable
-                        # that we can access later if we run out of attempts.
-                        error = error_
-                    else:
-                        break
-                else:
-                    # We have used up all our attempts. There seems to be an
-                    # actual problem. Raise the error stashed above.
-                    raise DataNotAccessible(
+                error_to_raise = DataNotAccessible(
                         f"Filler was unable to load the data referenced by "
                         f"the Datum document {datum_doc} and the Resource "
-                        f"document {resource}.") from error
+                        f"document {resource}.")
+                payload = _attempt_with_retries(
+                    func=handler,
+                    args=(),
+                    kwargs=datum_doc['datum_kwargs'],
+                    retry_intervals=self.retry_intervals,
+                    error_to_catch=IOError,
+                    error_to_raise=error_to_raise)
+                # Here we are intentionally modifying doc in place.
+                filled_doc['data'][key] = payload
+                filled_doc['filled'][key] = datum_id
         self._current_state.key = None
         self._current_state.descriptor = None
         return filled_doc
@@ -686,6 +678,41 @@ class Filler(DocumentRouter):
             raise EventModelRuntimeError(
                 "This Filler has been closed and is no longer usable.")
         return super().__call__(name, doc, validate)
+
+
+def _attempt_with_retries(func, args, kwargs,
+                          retry_intervals,
+                          error_to_catch, error_to_raise):
+    """
+    Return func(*args, **kwargs), using a retry loop.
+
+    func, args, kwargs: self-explanatory
+    retry_intervals: list
+        How long to wait (seconds) between before each successive retry.
+    error_to_catch: Exception class
+        If this is raised, retry.
+    error_to_raise: Exception instance or class
+        If we run out of retries, raise this from the proximate error.
+    """
+    # We are sure to attempt IO at least once and
+    # then perhaps additional times depending on the contents of
+    # retry_intervals.
+    error = None
+    for interval in [0] + retry_intervals:
+        ttime.sleep(interval)
+        try:
+            return func(*args, **kwargs)
+        except error_to_catch as error_:
+            # The file may not be visible on the network yet.
+            # Wait and try again. Stash the error in a variable
+            # that we can access later if we run out of attempts.
+            error = error_
+        else:
+            break
+    else:
+        # We have used up all our attempts. There seems to be an
+        # actual problem. Raise specified from the error stashed above.
+        raise error_to_raise from error
 
 
 class NoFiller(Filler):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -396,7 +396,7 @@ class Filler(DocumentRouter):
         self._datum_cache = datum_cache
         self._descriptor_cache = descriptor_cache
         if retry_intervals is None:
-            self.retry_intervals = []
+            retry_intervals = []
         self.retry_intervals = retry_intervals
         self._closed = False
 

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -859,3 +859,48 @@ def test_pack_empty_raises():
         event_model.pack_event_page()
     with pytest.raises(ValueError):
         event_model.pack_datum_page()
+
+
+def test_attempt_with_retires():
+    mutable = []
+    expected_args = (1, 2)
+    expected_kwargs = {'c': 3, 'd': 4}
+    expected_result = 10
+
+    class LocalException1(Exception):
+        pass
+
+    class LocalException2(Exception):
+        pass
+
+    def func(*args, **kwargs):
+        # Fails when called the first two times;
+        # on the third time, returns expected_result.
+        assert args == expected_args
+        assert kwargs == expected_kwargs
+        mutable.append(object())
+        if len(mutable) < 3:
+            raise LocalException1()
+        return expected_result
+
+    # Test with a total of three attempts, just sufficient to succeed.
+    result = event_model._attempt_with_retries(
+        func=func,
+        args=expected_args,
+        kwargs=expected_kwargs,
+        error_to_catch=LocalException1,
+        error_to_raise=LocalException2,
+        retry_intervals=[0.01, 0.01])
+    assert result == expected_result
+
+    mutable.clear()
+
+    # Test one fewer than the needed number of attempts to succeed.
+    with pytest.raises(LocalException2):
+        event_model._attempt_with_retries(
+            func=func,
+            args=expected_args,
+            kwargs=expected_kwargs,
+            error_to_catch=LocalException1,
+            error_to_raise=LocalException2,
+            retry_intervals=[0.01])

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -890,7 +890,7 @@ def test_attempt_with_retires():
         kwargs=expected_kwargs,
         error_to_catch=LocalException1,
         error_to_raise=LocalException2,
-        retry_intervals=[0.01, 0.01])
+        intervals=[0, 0.01, 0.01])
     assert result == expected_result
 
     mutable.clear()
@@ -903,4 +903,4 @@ def test_attempt_with_retires():
             kwargs=expected_kwargs,
             error_to_catch=LocalException1,
             error_to_raise=LocalException2,
-            retry_intervals=[0.01])
+            intervals=[0, 0.01])

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -861,6 +861,12 @@ def test_pack_empty_raises():
         event_model.pack_datum_page()
 
 
+@pytest.mark.parametrize('retry_intervals', [(1,), [1], (), [], None])
+def test_retry_intervals_input_normalization(retry_intervals):
+    filler = event_model.Filler({}, retry_intervals=retry_intervals)
+    assert isinstance(filler.retry_intervals, list)
+
+
 def test_attempt_with_retires():
     mutable = []
     expected_args = (1, 2)


### PR DESCRIPTION
We currently use a retry loop (with configurable time-spacing and number of
retries) when exchanging a Datum for a data payload. We should do the same
when exchanging a Resource for handler instance because that step can and
often does involve file I/O as well.

This factors out the retry loop into an internal utility function.


The resource health validator at FXI uses `filler.get_handler()` to
check that the HDF5 files are at least open-able. It is happening a
little too early and getting a false negative. Retries should fix it.


Tests were added targeting the newly-factored-out retry loop.