### PR TITLE
Fix unpack_event_page for page with empty 'data'.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1434,13 +1434,14 @@ def unpack_event_page(event_page):
     data_list = _transpose_dict_of_lists(event_page['data'])
     timestamps_list = _transpose_dict_of_lists(event_page['timestamps'])
     filled_list = _transpose_dict_of_lists(event_page.get('filled', {}))
-    for uid, time, seq_num, data, timestamps, filled in zip(
+    for uid, time, seq_num, data, timestamps, filled in itertools.zip_longest(
             event_page['uid'],
             event_page['time'],
             event_page['seq_num'],
             data_list,
             timestamps_list,
-            filled_list or [{}] * len(data_list)):
+            filled_list,
+            fillvalue={}):
         event = {'descriptor': descriptor,
                  'uid': uid, 'time': time, 'seq_num': seq_num,
                  'data': data, 'timestamps': timestamps, 'filled': filled}

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1188,22 +1188,29 @@ def test_attempt_with_retires():
             intervals=[0, 0.01])
 
 
-def test_unpack_event_page_with_empty_data():
+def test_round_trip_event_page_with_empty_data():
     event_page = {
         'time': [1, 2, 3],
         'seq_num': [1, 2, 3],
         'uid': ['a', 'b', 'c'],
         'descriptor': 'd',
         'data': {},
-        'timestamps': {}}
+        'timestamps': {},
+        'filled': {}}
     events = list(event_model.unpack_event_page(event_page))
     assert len(events) == 3
 
+    page_again = event_model.pack_event_page(*events)
+    assert page_again == event_page
 
-def test_unpack_datum_page_with_empty_data():
+
+def test_round_trip_datum_page_with_empty_data():
     datum_page = {
         'datum_id': ['a', 'b', 'c'],
         'resource': 'd',
         'datum_kwargs': {}}
     datums = list(event_model.unpack_datum_page(datum_page))
     assert len(datums) == 3
+
+    page_again = event_model.pack_datum_page(*datums)
+    assert page_again == datum_page

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1186,3 +1186,24 @@ def test_attempt_with_retires():
             error_to_catch=LocalException1,
             error_to_raise=LocalException2,
             intervals=[0, 0.01])
+
+
+def test_unpack_event_page_with_empty_data():
+    event_page = {
+        'time': [1, 2, 3],
+        'seq_num': [1, 2, 3],
+        'uid': ['a', 'b', 'c'],
+        'descriptor': 'd',
+        'data': {},
+        'timestamps': {}}
+    events = list(event_model.unpack_event_page(event_page))
+    assert len(events) == 3
+
+
+def test_unpack_datum_page_with_empty_data():
+    datum_page = {
+        'datum_id': ['a', 'b', 'c'],
+        'resource': 'd',
+        'datum_kwargs': {}}
+    datums = list(event_model.unpack_datum_page(datum_page))
+    assert len(datums) == 3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fixes a bug in `unpack_event_page`.

## Motivation and Context
In @gwbischof's work on https://github.com/bluesky/databroker/issues/507 he encountered a bug in `unpack_event_page` exercised in the rare but valid case where an Event document has empty `data` and `timestamps` dicts.

We hit the analogous issue for Datum documents with empty `datum_kwargs` dict awhile back and fixed `unpack_datum_page` in d179f29f but neglected to recognize that the same fix would need to be applied for `unpack_event_page`.

## How Has This Been Tested?
Added tests for both the Event and Datum case, both unpacking and packing.