### PR TITLE
RunRouter passes more docs to callbacks.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -872,6 +872,18 @@ class NoFiller(Filler):
         return doc
 
 
+DOCS_PASSED_IN_1_14_0_WARNING = (
+    "The callback {callback!r} raised {err!r} when "
+    "RunRouter passed it a {name!r} document. This is "
+    "probably because in earlier releases the RunRouter "
+    "expected its factory functions forward the 'start' "
+    "document, but starting in event-model 1.14.0 the "
+    "RunRouter passes in the document, causing the "
+    "callback to receive it twice and potentially raise "
+    "an error. Update the factory function. In a future "
+    "release this warning will become an error.")
+
+
 class RunRouter(DocumentRouter):
     """
     Routes documents, by run, to callbacks it creates from factory functions.
@@ -1012,15 +1024,8 @@ class RunRouter(DocumentRouter):
                     callback('start', doc)
                 except Exception as err:
                     warnings.warn(
-                        f"The callback {callback} raised a {err} when "
-                        f"RunRouter passed it a 'start' document. This is "
-                        f"probably because in earlier releases the RunRouter "
-                        f"expected its factory functions forward the 'start' "
-                        f"document, but starting in event-model 1.14.0 the "
-                        f"RunRouter passes in the document, causing the "
-                        f"callback to receive it twice and potentially raise "
-                        f"an error. Update the factory function. In a future "
-                        f"release this warning will become an error.")
+                        DOCS_PASSED_IN_1_14_0_WARNING.format(
+                            callback=callback, name='start', err=err))
             self._factory_cbs_by_start[uid].extend(callbacks)
             self._subfactories[uid].extend(subfactories)
 
@@ -1043,28 +1048,14 @@ class RunRouter(DocumentRouter):
                     callback('start', doc)
                 except Exception as err:
                     warnings.warn(
-                        f"The callback {callback} raised a {err} when "
-                        f"RunRouter passed it a 'start' document. This is "
-                        f"probably because in earlier releases the RunRouter "
-                        f"expected its factory functions forward the 'start' "
-                        f"document, but starting in event-model 1.14.0 the "
-                        f"RunRouter passes in the document, causing the "
-                        f"callback to receive it twice and potentially raise "
-                        f"an error. Update the factory function. In a future "
-                        f"release this warning will become an error.")
+                        DOCS_PASSED_IN_1_14_0_WARNING.format(
+                            callback=callback, name='start', err=err))
                 try:
                     callback('descriptor', doc)
-                except Exception:
+                except Exception as err:
                     warnings.warn(
-                        f"The callback {callback} raised a {err} when "
-                        f"RunRouter passed it a 'descriptor' document. This is "
-                        f"probably because in earlier releases the RunRouter "
-                        f"expected its subfactory functions forward the 'descriptor' "
-                        f"document, but starting in event-model 1.14.0 the "
-                        f"RunRouter passes in the document, causing the "
-                        f"callback to receive it twice and potentially raise "
-                        f"an error. Update the subfactory function. In a future "
-                        f"release this warning will become an error.")
+                        DOCS_PASSED_IN_1_14_0_WARNING.format(
+                            callback=callback, name='descriptor', err=err))
         # Keep track of the RunStart UID -> [EventDescriptor UIDs] mapping for
         # purposes of cleanup in stop().
         self._descriptors[start_uid].append(uid)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -899,16 +899,17 @@ class RunRouter(DocumentRouter):
 
             callback(name, doc)
 
-        that will receive all subsequent documents from the run including the
-        RunStop document. All items in the second list should be "subfactories"
-        with the signature::
+        that will receive that RunStart document and all subsequent documents
+        from the run including the RunStop document. All items in the second
+        list should be "subfactories" with the signature::
 
             subfactory('descriptor', descriptor_doc) -> List[Callbacks]
 
         These will receive each of the EventDescriptor documents for the run,
         as they arrive. They must return one list, which may be empty,
-        containing callbacks that will receive all Events that reference that
-        EventDescriptor and finally the RunStop document for the run.
+        containing callbacks that will receive the RunStart document, that
+        EventDescriptor, all Events that reference that EventDescriptor and
+        finally the RunStop document for the run.
     handler_registry : dict, optional
         This is passed to the Filler or whatever class is given in the
         filler_class parametr below.
@@ -1006,6 +1007,20 @@ class RunRouter(DocumentRouter):
         # because Fillers do nothing with 'start'.
         for factory in self.factories:
             callbacks, subfactories = factory('start', doc)
+            for callback in callbacks:
+                try:
+                    callback('start', doc)
+                except Exception as err:
+                    warnings.warn(
+                        f"The callback {callback} raised a {err} when "
+                        f"RunRouter passed it a 'start' document. This is "
+                        f"probably because in earlier releases the RunRouter "
+                        f"expected its factory functions forward the 'start' "
+                        f"document, but starting in event-model 1.14.0 the "
+                        f"RunRouter passes in the document, causing the "
+                        f"callback to receive it twice and potentially raise "
+                        f"an error. Update the factory function. In a future "
+                        f"release this warning will become an error.")
             self._factory_cbs_by_start[uid].extend(callbacks)
             self._subfactories[uid].extend(subfactories)
 
@@ -1023,6 +1038,33 @@ class RunRouter(DocumentRouter):
             callbacks = subfactory('descriptor', doc)
             self._subfactory_cbs_by_start[start_uid].extend(callbacks)
             self._subfactory_cbs_by_descriptor[uid].extend(callbacks)
+            for callback in callbacks:
+                try:
+                    callback('start', doc)
+                except Exception as err:
+                    warnings.warn(
+                        f"The callback {callback} raised a {err} when "
+                        f"RunRouter passed it a 'start' document. This is "
+                        f"probably because in earlier releases the RunRouter "
+                        f"expected its factory functions forward the 'start' "
+                        f"document, but starting in event-model 1.14.0 the "
+                        f"RunRouter passes in the document, causing the "
+                        f"callback to receive it twice and potentially raise "
+                        f"an error. Update the factory function. In a future "
+                        f"release this warning will become an error.")
+                try:
+                    callback('descriptor', doc)
+                except Exception:
+                    warnings.warn(
+                        f"The callback {callback} raised a {err} when "
+                        f"RunRouter passed it a 'descriptor' document. This is "
+                        f"probably because in earlier releases the RunRouter "
+                        f"expected its subfactory functions forward the 'descriptor' "
+                        f"document, but starting in event-model 1.14.0 the "
+                        f"RunRouter passes in the document, causing the "
+                        f"callback to receive it twice and potentially raise "
+                        f"an error. Update the subfactory function. In a future "
+                        f"release this warning will become an error.")
         # Keep track of the RunStart UID -> [EventDescriptor UIDs] mapping for
         # purposes of cleanup in stop().
         self._descriptors[start_uid].append(uid)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -876,7 +876,7 @@ DOCS_PASSED_IN_1_14_0_WARNING = (
     "The callback {callback!r} raised {err!r} when "
     "RunRouter passed it a {name!r} document. This is "
     "probably because in earlier releases the RunRouter "
-    "expected its factory functions forward the 'start' "
+    "expected its factory functions to forward the 'start' "
     "document, but starting in event-model 1.14.0 the "
     "RunRouter passes in the document, causing the "
     "callback to receive it twice and potentially raise "

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1102,17 +1102,16 @@ def test_run_router(tmp_path):
     class LocalException3(Exception):
         ...
 
-    def collector(name, doc):
+    def header_collector(name, doc):
         if name in ('start', 'stop', 'descriptor'):
             key = (name, doc['uid'])
             if key in collected_header_docs:
                 raise LocalException3
             collected_header_docs[key] = doc
 
-
     def all_factory(name, doc):
-        collector(name, doc)
-        return [collector], []
+        header_collector(name, doc)
+        return [header_collector], []
 
     rr = event_model.RunRouter([all_factory])
     with pytest.warns(UserWarning, match='1.14.0'):
@@ -1124,12 +1123,12 @@ def test_run_router(tmp_path):
     # Test subfactory that expects old (pre-1.14.0) RunRouter behavior.
 
     def factory_with_subfactory_only(name, doc):
-        collector(name, doc)
+        header_collector(name, doc)
 
         def subfactory(name, doc):
             if doc.get('name') == 'baseline':
-                collector(name, doc)
-                return [collector]
+                header_collector(name, doc)
+                return [header_collector]
             return []
 
         return [], [subfactory]

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1067,7 +1067,6 @@ def test_run_router(tmp_path):
         collected.append((name, doc))
 
     def all_factory(name, doc):
-        collector(name, doc)
         return [collector], []
 
     rr = event_model.RunRouter([all_factory])


### PR DESCRIPTION
Closes #149. See that issue for discussion.

Needs tests before merging.