### PR TITLE
MNT: python has deprecated using NotImplemented in bools

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1300,6 +1300,7 @@ for name, filename in SCHEMA_NAMES.items():
 
 def _is_array(checker, instance):
     return (
+        isinstance(instance, numpy.ndarray) or
         jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or
         isinstance(instance, tuple)
     )

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -88,14 +88,16 @@ class DocumentRouter:
                 event_page = pack_event_page(doc)
                 # Subclass' implementation of event_page may return a valid
                 # EventPage or None or NotImplemented.
-                output_event_page = self.event_page(event_page) or event_page
+                output_event_page = self.event_page(event_page)
+                output_event_page = output_event_page if output_event_page is not None else event_page
                 if output_event_page is not NotImplemented:
                     output_doc, = unpack_event_page(output_event_page)
             elif name == 'datum':
                 datum_page = pack_datum_page(doc)
                 # Subclass' implementation of datum_page may return a valid
                 # DatumPage or None or NotImplemented.
-                output_datum_page = self.datum_page(datum_page) or datum_page
+                output_datum_page = self.datum_page(datum_page)
+                output_datum_page = output_datum_page if output_datum_page is not None else datum_page
                 if output_datum_page is not NotImplemented:
                     output_doc, = unpack_datum_page(output_datum_page)
             elif name == 'event_page':
@@ -103,7 +105,8 @@ class DocumentRouter:
                 for event in unpack_event_page(doc):
                     # Subclass' implementation of event may return a valid
                     # Event or None or NotImplemented.
-                    output_event = self.event(event) or event
+                    output_event = self.event(event)
+                    output_event = output_event if output_event is not None else event
                     if output_event is NotImplemented:
                         break
                     output_events.append(output_event)
@@ -114,7 +117,8 @@ class DocumentRouter:
                 for datum in unpack_datum_page(doc):
                     # Subclass' implementation of datum may return a valid
                     # Datum or None or NotImplemented.
-                    output_datum = self.datum(datum) or datum
+                    output_datum = self.datum(datum)
+                    output_datum = output_datum if output_datum is not None else datum
                     if output_datum is NotImplemented:
                         break
                     output_datums.append(output_datum)


### PR DESCRIPTION
.../event-model/event_model/__init__.py:98: DeprecationWarning: NotImplemented should not be used in a boolean context
  output_datum_page = self.datum_page(datum_page) or datum_page

Taking the bool of `NotImplemented` is deprecated in py39


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->