### PR TITLE
Add convenience methods and new warning to DocumentRouter

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -18,6 +18,10 @@ a schema and an associated :class:`jsonschema.IValidator`.
    :members:
    :undoc-members:
 
+.. autoclass:: event_model.SingleRunDocumentRouter
+   :members:
+   :undoc-members:
+
 .. autoclass:: event_model.DocumentRouter
    :members:
    :undoc-members:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -185,6 +185,7 @@ class SingleRunDocumentRouter(DocumentRouter):
     A DocumentRouter intended to process events from exactly one run.
     """
     def __init__(self):
+        super().__init__()
         self._start_doc = None
         self._descriptors = dict()
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -214,15 +214,17 @@ class SingleRunDocumentRouter(DocumentRouter):
             if self._start_doc is None:
                 self._start_doc = doc
             else:
-                raise EventModelError(
-                    'SingleRunDocumentRouter received a second start document: uid {doc["uid"]}'
+                raise EventModelValueError(
+                    f'SingleRunDocumentRouter associated with start document {self._start_doc["uid"]} '
+                    f'received a second start document with uid {doc["uid"]}'
                 )
         elif name == 'descriptor':
             if doc['run_start'] == self._start_doc['uid']:
                 self._descriptors[doc['uid']] = doc
             else:
-                raise EventModelError(
-                    'SingleRunDocumentRouter received a descriptor associated with a different start document'
+                raise EventModelValueError(
+                    f'SingleRunDocumentRouter associated with start document {self._start_doc["uid"]} '
+                    f'received a descriptor {doc["uid"]} associated with start document {doc["run_start"]}'
                 )
 
         return super().__call__(name, doc, validate)
@@ -254,10 +256,10 @@ class SingleRunDocumentRouter(DocumentRouter):
         descriptor document : dict
         """
         if 'descriptor' not in doc:
-            raise ValueError(f'document is not associated with a descriptor:\n{doc}')
+            raise EventModelValueError(f'document is not associated with a descriptor:\n{doc}')
         elif doc['descriptor'] not in self._descriptors:
-            raise EventModelError(
-                'SingleRunDocumentRouter has not processed a descriptor with uid {doc["descriptor"]}'
+            raise EventModelValueError(
+                f'SingleRunDocumentRouter has not processed a descriptor with uid {doc["descriptor"]}'
             )
 
         return self._descriptors[doc['descriptor']]

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -95,7 +95,7 @@ class DocumentRouter:
         return self._descriptors[event_doc['descriptor']]
 
     def get_stream_name(self, event_doc):
-        return self.get_descriptor(event_doc)['stream']
+        return self.get_descriptor(event_doc)['name']
 
     def _dispatch(self, name, doc, validate):
         """

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -182,8 +182,7 @@ class DocumentRouter:
 
 class SingleRunDocumentRouter(DocumentRouter):
     """
-    A DocumentRouter intended to process events from exactly
-    one run.
+    A DocumentRouter intended to process events from exactly one run.
     """
     def __init__(self):
         self._start_doc = None

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -191,10 +191,10 @@ class SingleRunDocumentRouter(DocumentRouter):
 
     def __call__(self, name, doc, validate=False):
         """
-        Keep track of the start document and descriptor documents
-        passed to this SingleRunDocumentRouter.
+        Process a document.
 
-        Send documents to the superclass for processing.
+        Also, track of the start document and descriptor documents
+        passed to this SingleRunDocumentRouter in caches.
 
         Parameters
         ----------
@@ -226,7 +226,7 @@ class SingleRunDocumentRouter(DocumentRouter):
                     f'SingleRunDocumentRouter associated with start document {self._start_doc["uid"]} '
                     f'received a descriptor {doc["uid"]} associated with start document {doc["run_start"]}'
                 )
-
+        # Defer to superclass for dispatch/processing.
         return super().__call__(name, doc, validate)
 
     def get_start(self):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1181,6 +1181,7 @@ class RunRouter(DocumentRouter):
                     warnings.warn(
                         DOCS_PASSED_IN_1_14_0_WARNING.format(
                             callback=callback, name='start', err=err))
+                    raise err
             self._factory_cbs_by_start[uid].extend(callbacks)
             self._subfactories[uid].extend(subfactories)
 
@@ -1205,12 +1206,14 @@ class RunRouter(DocumentRouter):
                     warnings.warn(
                         DOCS_PASSED_IN_1_14_0_WARNING.format(
                             callback=callback, name='start', err=err))
+                    raise err
                 try:
                     callback('descriptor', doc)
                 except Exception as err:
                     warnings.warn(
                         DOCS_PASSED_IN_1_14_0_WARNING.format(
                             callback=callback, name='descriptor', err=err))
+                    raise err
         # Keep track of the RunStart UID -> [EventDescriptor UIDs] mapping for
         # purposes of cleanup in stop().
         self._descriptors[start_uid].append(uid)

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -617,6 +617,79 @@ def test_document_router_dispatch_datum():
     datum_page_calls.clear()
 
 
+def test_single_run_document_router():
+    sr = event_model.SingleRunDocumentRouter()
+    with pytest.raises(event_model.EventModelError):
+        sr.get_start()
+
+    run_bundle = event_model.compose_run()
+    sr('start', run_bundle.start_doc)
+    assert sr.get_start() == run_bundle.start_doc
+
+    desc_bundle = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
+                   'image': {'shape': [512, 512], 'dtype': 'number',
+                             'source': '...', 'external': 'FILESTORE:'}},
+        name='primary')
+    sr('descriptor', desc_bundle.descriptor_doc)
+    desc_bundle_baseline = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
+        name='baseline')
+    sr('descriptor', desc_bundle_baseline.descriptor_doc)
+    res_bundle = run_bundle.compose_resource(
+        spec='TIFF', root='/tmp', resource_path='stack.tiff',
+        resource_kwargs={})
+    sr('resource', res_bundle.resource_doc)
+    datum_doc1 = res_bundle.compose_datum(datum_kwargs={'slice': 5})
+    datum_doc2 = res_bundle.compose_datum(datum_kwargs={'slice': 10})
+    sr('datum', datum_doc1)
+    sr('datum', datum_doc2)
+    event1 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': datum_doc1['datum_id']},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
+        seq_num=1)
+    sr('event', event1)
+    event2 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': datum_doc2['datum_id']},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
+        seq_num=2)
+    sr('event', event2)
+    event3 = desc_bundle_baseline.compose_event(
+        data={'motor': 0},
+        timestamps={'motor': 0},
+        seq_num=1)
+    sr('event', event3)
+
+    with pytest.raises(ValueError):
+        sr.get_descriptor(res_bundle.resource_doc)
+
+    with pytest.raises(ValueError):
+        sr.get_descriptor(datum_doc1)
+
+    assert sr.get_descriptor(event1) == desc_bundle.descriptor_doc
+    assert sr.get_stream_name(event1) == desc_bundle.descriptor_doc.get('name')
+    assert sr.get_descriptor(event2) == desc_bundle.descriptor_doc
+    assert sr.get_stream_name(event2) == desc_bundle.descriptor_doc.get('name')
+    assert sr.get_descriptor(event3) == desc_bundle_baseline.descriptor_doc
+    assert sr.get_stream_name(event3) == desc_bundle_baseline.descriptor_doc.get('name')
+
+    desc_bundle_unused = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
+        name='unused')
+    event4 = desc_bundle_unused.compose_event(
+        data={'motor': 0},
+        timestamps={'motor': 0},
+        seq_num=1)
+
+    with pytest.raises(event_model.EventModelError):
+        sr.get_descriptor(event4)
+
+    with pytest.raises(event_model.EventModelError):
+        sr.get_stream_name(event4)
+
+    sr('stop', run_bundle.compose_stop())
+
+
 def test_filler(tmp_path):
 
     class DummyHandler:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -660,10 +660,10 @@ def test_single_run_document_router():
         seq_num=1)
     sr('event', event3)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(event_model.EventModelValueError):
         sr.get_descriptor(res_bundle.resource_doc)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(event_model.EventModelValueError):
         sr.get_descriptor(datum_doc1)
 
     assert sr.get_descriptor(event1) == desc_bundle.descriptor_doc
@@ -681,13 +681,26 @@ def test_single_run_document_router():
         timestamps={'motor': 0},
         seq_num=1)
 
-    with pytest.raises(event_model.EventModelError):
+    with pytest.raises(event_model.EventModelValueError):
         sr.get_descriptor(event4)
 
-    with pytest.raises(event_model.EventModelError):
+    with pytest.raises(event_model.EventModelValueError):
         sr.get_stream_name(event4)
 
     sr('stop', run_bundle.compose_stop())
+
+    # tests against a second run
+    run_bundle = event_model.compose_run()
+    with pytest.raises(event_model.EventModelValueError):
+        sr('start', run_bundle.start_doc)
+
+    desc_bundle = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
+                   'image': {'shape': [512, 512], 'dtype': 'number',
+                             'source': '...', 'external': 'FILESTORE:'}},
+        name='primary')
+    with pytest.raises(event_model.EventModelValueError):
+        sr('descriptor', desc_bundle.descriptor_doc)
 
 
 def test_filler(tmp_path):

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1189,7 +1189,7 @@ def test_run_router(tmp_path):
         return [header_collector], []
 
     rr = event_model.RunRouter([all_factory])
-    with pytest.warns(UserWarning, match='1.14.0'):
+    with pytest.warns(UserWarning, match='1.14.0'), pytest.raises(LocalException3):
         for name, doc in docs:
             rr(name, doc)
 
@@ -1209,7 +1209,7 @@ def test_run_router(tmp_path):
         return [], [subfactory]
 
     rr = event_model.RunRouter([factory_with_subfactory_only])
-    with pytest.warns(UserWarning, match='1.14.0'):
+    with pytest.warns(UserWarning, match='1.14.0'), pytest.raises(LocalException3):
         for name, doc in docs:
             rr(name, doc)
 


### PR DESCRIPTION
This PR proposes two modifications to DocumentRouter:

- deliver a warning if a DocumentRouter processes the same start document twice consecutively to address #164

- add convenience methods to address #165 
  - `get_start()` returning the most recently processed start document
  - `get_descriptor(event_doc)` returning the descriptor document corresponding to the specified event document
  - `get_stream_name(event_doc)` returning the stream name for the specified event document; this seems like a minor convenience but it is the piece of information I very often want from a descriptor

The convenience methods are prefixed with `get_` since DocumentRouter already defines `start(name, doc)` and `descriptor(name, doc)` but some other naming scheme might be better.

I realize now that the `event_doc` parameter for `get_descriptor` and `get_stream_name` should probably just be `doc`.
