### PR TITLE
The wrong schema is shown under Event Descriptor.

### DIFF
--- a/docs/source/data-model.rst
+++ b/docs/source/data-model.rst
@@ -209,7 +209,7 @@ Typical example:
 
 Formal schema:
 
-.. literalinclude:: ../../event_model/schemas/run_start.json
+.. literalinclude:: ../../event_model/schemas/event_descriptor.json
 
 .. _event:
 


### PR DESCRIPTION
We show the RunStart schema again instead of showing the EventDescriptor
one.