### PR TITLE
Fix sphinx build.

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -20,7 +20,7 @@ Changed
 * In v1.14.0, :class:`~event_model.RunRouter` was changed to pass the
   RunStart document directly to its callbacks. To smooth the transition, any
   ``Exception`` raised by the callbacks was squashed and a warning printed. With
-  v1.15.0 these ``Exception``s are allowed to propagate. The warning is still
+  v1.15.0 these Exceptions are allowed to propagate. The warning is still
   printed.
 
 


### PR DESCRIPTION
The `master` branch currently fails to build docs, with this warning:

```
Warning, treated as error:
/home/travis/build/bluesky/event-model/docs/source/release-history.rst:20:Inline literal start-string without end-string.
Makefile:20: recipe for target 'html' failed
```

This was introduced in #168 and released in that broken state as 1.15.0.
In #168 the Travis-CI webhook didn't fire, so it was accidentally merged
without tests having been run. The commit tagged 1.15.0 failed here:

https://travis-ci.org/github/bluesky/event-model/jobs/680576809

which I noticed because the new docs were not published.