### PR TITLE
WIP: make the timestamps part of the payload optional

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1506,7 +1506,7 @@ def compose_stop(*, start, event_counter, poison_pill,
     return doc
 
 
-def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
+def compose_event_page(*, descriptor, event_counter, data, timestamps=None, seq_num,
                        filled=None, uid=None, time=None, validate=True):
     N = len(seq_num)
     if uid is None:
@@ -1518,13 +1518,15 @@ def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
     doc = {'uid': uid,
            'time': time,
            'data': data,
-           'timestamps': timestamps,
            'seq_num': seq_num,
            'filled': filled,
            'descriptor': descriptor['uid']}
+    if timestamps is not None:
+        doc['timestamps'] = timestamps
     if validate:
         schema_validators[DocumentNames.event_page].validate(doc)
-        if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
+        if not (descriptor['data_keys'].keys() == data.keys() and
+                (timestamps is None or data.keys() == timestamps.keys())):
             raise EventModelValidationError(
                 "These sets of keys must match:\n"
                 "event['data'].keys(): {}\n"
@@ -1539,7 +1541,7 @@ def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
     return doc
 
 
-def compose_event(*, descriptor, event_counter, data, timestamps, seq_num=None,
+def compose_event(*, descriptor, event_counter, data, timestamps=None, seq_num=None,
                   filled=None, uid=None, time=None, validate=True):
     if seq_num is None:
         seq_num = event_counter[descriptor['name']]
@@ -1552,13 +1554,15 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num=None,
     doc = {'uid': uid,
            'time': time,
            'data': data,
-           'timestamps': timestamps,
            'seq_num': seq_num,
            'filled': filled,
            'descriptor': descriptor['uid']}
+    if timestamps is not None:
+        doc['timestamps'] = timestamps
     if validate:
         schema_validators[DocumentNames.event].validate(doc)
-        if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
+        if not (descriptor['data_keys'].keys() == data.keys() and
+                (timestamps is None or data.keys() == timestamps.keys())):
             raise EventModelValidationError(
                 "These sets of keys must match:\n"
                 "event['data'].keys(): {}\n"

--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -33,7 +33,6 @@
     "required": [
         "uid",
         "data",
-        "timestamps",
         "time",
         "descriptor",
         "seq_num"

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -66,7 +66,6 @@
         "descriptor",
         "uid",
         "data",
-        "timestamps",
         "time",
         "seq_num"
     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes 'timestamps' option in the event schema, event page schema, and compose_* APIs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discussed on today pilot call, the `'timestamps'` entry makes a lot of sense when the ultimate source of the data is a control systems (and fundamentally asynchronous) but makes much less sense for the output of data analysis.  

This is the minimal change to event model to allow this.  There will need to be a companion change to databroker to cope with data that may not have timestamps.