### PR TITLE
Re-instate compatiblity with jsonschema 2.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
     - python: 3.6
     - python: 3.7
       env: PUBLISH_DOCS=1
+    - python: 3.7
+      env: JSONSCHEMA_2=1
+    - python: 3.8
     - python: nightly
   allow_failures:
     - python: nightly
@@ -27,6 +30,11 @@ install:
   - pip install .
   # Install extra requirements for running tests and building docs.
   - pip install -r requirements-dev.txt
+  # In some builds, tests against older jsonschema.
+  - |
+    if [ $JSONSCHEMA_2 ]; then
+      pip install "jsonschema==2"
+    fi
 
 script:
   - coverage run -m pytest  # Run the tests and check for test coverage.


### PR DESCRIPTION
Follow-up on #79 which added compatibility for jsonschema 3.x but
broke compatibility for 2.x. In this PR, we support both by defining
`schema_validators` conditional on the jsonschema version.

Tested by doing a simple bluesky scan.

Closes #145. See that issue for justification.