### PR TITLE
Give Subclass a better name.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -348,6 +348,8 @@ def force_numpy(handler_class, filler_state):
             raw_result = super().__call__(*args, **kwargs)
             result_as_array = numpy.asarray(raw_result)
             return result_as_array
+    Subclass.__name__ = f"Subclassed{handler_class.__name__}"
+    Subclass.__qualname__ = f"Subclassed{handler_class.__qualname__}"
     return Subclass
 
 


### PR DESCRIPTION
This will make more useful tracebacks.

We currently subclass handler classes dynamically, and the name of the
resulting subclass is `Subclass`. This makes it impossible to know from
a traceback which actual underlying handler class is creating a problem.