### PR TITLE
Add support for chaining DocumentRouters.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -76,21 +76,21 @@ class DocumentRouter:
                 raise ValueError("emit must accept two positional arguments, name and doc")
             # Stash a weak reference to `emit`.
             if inspect.ismethod(emit):
-                self._downstream = weakref.WeakMethod(emit)
+                self._emit_ref = weakref.WeakMethod(emit)
             else:
-                self._downstream = weakref.ref(emit)
+                self._emit_ref = weakref.ref(emit)
         else:
-            self._downstream = None
+            self._emit_ref = None
 
     def emit(self, name, doc):
         """
         Emit to the callable provided an instantiation time, if any.
         """
-        if self._downstream is not None:
+        if self._emit_ref is not None:
             # Call the weakref.
-            ref = self._downstream()
-            if ref is not None:
-                ref(name, doc)
+            emit = self._emit_ref()
+            if emit is not None:
+                emit(name, doc)
 
     def __call__(self, name, doc, validate=False):
         """

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -73,7 +73,7 @@ class DocumentRouter:
                 # Does this function accept two positional arguments?
                 sig.bind(None, None)
             except TypeError:
-                raise ValueError("emit must accept two position arguments, name and doc")
+                raise ValueError("emit must accept two positional arguments, name and doc")
             # Stash a weak reference to `emit`.
             if inspect.ismethod(emit):
                 self._downstream = weakref.WeakMethod(emit)

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,5 +1,4 @@
 import copy
-import gc
 import json
 import pickle
 
@@ -1197,71 +1196,3 @@ def test_pickle_filler():
     serialized = pickle.dumps(filler)
     deserialized = pickle.loads(serialized)
     assert filler == deserialized
-
-
-def test_emit():
-    collector = []
-
-    def cb(name, doc):
-        collector.append((name, doc))
-
-    router = event_model.DocumentRouter(emit=cb)
-    name = 'start'
-    doc = {'uid': 'asdf', 'time': 0}
-    router.emit(name, doc)
-    assert len(collector) == 1
-    assert collector == [(name, doc)]
-
-    # Test that we hold a weakref only.
-    del cb
-    gc.collect()
-    router.emit(name, doc)
-    assert len(collector) == 1
-
-
-def test_emit_with_method():
-    collector = []
-
-    class Thing:
-        def cb(self, name, doc):
-            collector.append((name, doc))
-
-    thing = Thing()
-
-    router = event_model.DocumentRouter(emit=thing.cb)
-    name = 'start'
-    doc = {'uid': 'asdf', 'time': 0}
-    router.emit(name, doc)
-    assert len(collector) == 1
-    assert collector == [(name, doc)]
-
-    # Test that we hold a weakref only.
-    del thing
-    gc.collect()
-    router.emit(name, doc)
-    assert len(collector) == 1
-
-
-def test_emit_validation():
-    """
-    Anything but a callable that accepts two arguments should raise ValueError.
-    """
-
-    # Not callable
-    with pytest.raises(ValueError):
-        event_model.DocumentRouter(emit=1)
-
-    # Wrong callback signature
-    with pytest.raises(ValueError):
-        event_model.DocumentRouter(emit=lambda: None)
-
-    # Wrong callback signature
-    with pytest.raises(ValueError):
-        event_model.DocumentRouter(emit=lambda a: None)
-
-    # Wrong callback signature
-    with pytest.raises(ValueError):
-        event_model.DocumentRouter(emit=lambda a, b, c: None)
-
-    # Right callback signature
-    event_model.DocumentRouter(emit=lambda a, b: None)

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,4 +1,5 @@
 import copy
+import gc
 import json
 import pickle
 
@@ -1196,3 +1197,71 @@ def test_pickle_filler():
     serialized = pickle.dumps(filler)
     deserialized = pickle.loads(serialized)
     assert filler == deserialized
+
+
+def test_emit():
+    collector = []
+
+    def cb(name, doc):
+        collector.append((name, doc))
+
+    router = event_model.DocumentRouter(emit=cb)
+    name = 'start'
+    doc = {'uid': 'asdf', 'time': 0}
+    router.emit(name, doc)
+    assert len(collector) == 1
+    assert collector == [(name, doc)]
+
+    # Test that we hold a weakref only.
+    del cb
+    gc.collect()
+    router.emit(name, doc)
+    assert len(collector) == 1
+
+
+def test_emit_with_method():
+    collector = []
+
+    class Thing:
+        def cb(self, name, doc):
+            collector.append((name, doc))
+
+    thing = Thing()
+
+    router = event_model.DocumentRouter(emit=thing.cb)
+    name = 'start'
+    doc = {'uid': 'asdf', 'time': 0}
+    router.emit(name, doc)
+    assert len(collector) == 1
+    assert collector == [(name, doc)]
+
+    # Test that we hold a weakref only.
+    del thing
+    gc.collect()
+    router.emit(name, doc)
+    assert len(collector) == 1
+
+
+def test_emit_validation():
+    """
+    Anything but a callable that accepts two arguments should raise ValueError.
+    """
+
+    # Not callable
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=1)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda: None)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda a: None)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda a, b, c: None)
+
+    # Right callback signature
+    event_model.DocumentRouter(emit=lambda a, b: None)

--- a/event_model/tests/test_emit.py
+++ b/event_model/tests/test_emit.py
@@ -1,0 +1,72 @@
+import gc
+
+import event_model
+import pytest
+
+
+def test_emit():
+    collector = []
+
+    def cb(name, doc):
+        collector.append((name, doc))
+
+    router = event_model.DocumentRouter(emit=cb)
+    name = 'start'
+    doc = {'uid': 'asdf', 'time': 0}
+    router.emit(name, doc)
+    assert len(collector) == 1
+    assert collector == [(name, doc)]
+
+    # Test that we hold a weakref only.
+    del cb
+    gc.collect()
+    router.emit(name, doc)
+    assert len(collector) == 1
+
+
+def test_emit_with_method():
+    collector = []
+
+    class Thing:
+        def cb(self, name, doc):
+            collector.append((name, doc))
+
+    thing = Thing()
+
+    router = event_model.DocumentRouter(emit=thing.cb)
+    name = 'start'
+    doc = {'uid': 'asdf', 'time': 0}
+    router.emit(name, doc)
+    assert len(collector) == 1
+    assert collector == [(name, doc)]
+
+    # Test that we hold a weakref only.
+    del thing
+    gc.collect()
+    router.emit(name, doc)
+    assert len(collector) == 1
+
+
+def test_emit_validation():
+    """
+    Anything but a callable that accepts two arguments should raise ValueError.
+    """
+
+    # Not callable
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=1)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda: None)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda a: None)
+
+    # Wrong callback signature
+    with pytest.raises(ValueError):
+        event_model.DocumentRouter(emit=lambda a, b, c: None)
+
+    # Right callback signature
+    event_model.DocumentRouter(emit=lambda a, b: None)


### PR DESCRIPTION
This addresses a long-considered need in DocumentRouter: the ability to chain them.

## Description

A common use case would be connecting a DocumentRouter that does some transformation (e.g. dark subtraction) to a DocumentRouter that does visualization or serialization. Currently, the only way to do this is:

```py
def factory(name, doc):
    router3 = Router3(...)
    router2 = Router2(...)
    router1 = Router1(...)

    def cb(name, doc):
        name1, doc1 = router1(name, doc)
        name2, doc2 = router2(name1, doc1)
        router3(name2, doc2)
    return [cb], []

RunRouter([factory])
```

which is verbose and error-prone. This PR enables:

```py
def factory(name, doc):
    router3 = Router3(...)
    router2 = Router2(..., emit=router3)
    router1 = Router1(..., emit=router2)
    return [router1], []

RunRouter([factory])
```

## Design Considerations

1. The relationship between documents received and documents emitted does not have to be 1:1. Note that the base class does not _call_ `emit` internally at all. It is up to subclasses to define whether and when to emit. For example, `Serializer` classes and classes that produce visualizations are generally "sinks" and have no need to incur the overhead of emitting the documents to a downstream node. Some applications ([example](https://github.com/bluesky/suitcase-dataexchange/blob/91821b8d06baf2dbf910b8b232b1d5ebd0ebbf5f/migrate.py)) may one to emit multiple documents when they receive a single document.
2. This emits straightforwardly to at most one downstream node. For more complex behavior, like fanning out to multiple nodes, handling backpressure, and other considerations, the user should engage a more complex library like [streamz](https://github.com/python-streamz/streamz) by registering a Stream node with `emit`. By accepting this one additional layer of indirection, we keep these considerations separate from event-model.

## Alternatives Considered

We could leave it up to subclasses to add `emit` but a standard `emit` method and `__init__` parameter


