### PR TITLE
DOC: shape cannot be None

### DIFF
--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -25,7 +25,7 @@
                         "items": {
                             "type": "integer"
                         },
-                        "description": "The shape of the data.  Null and empty list mean scalar data."
+                        "description": "The shape of the data.  Empty list indicates scalar data."
                     },
                     "dims": {
                         "type": "array",


### PR DESCRIPTION
This PR fixes the docstring for the "shape" field.

see also https://github.com/bluesky/bluesky/pull/1375

[1] http://nsls-ii.github.io/bluesky/hardware.html#ReadableDevice.describe
[2] https://github.com/bluesky/event-model/blob/f33e54ac88ca7fa8588acd41a1f7e41b7610c269/event_model/schemas/event_descriptor.json#L23-L28