### PR TITLE
Include resource, datum in filler_state.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -905,6 +905,8 @@ class Filler(DocumentRouter):
                     resource_uid,
                     f"Datum with id {datum_id} refers to unknown Resource "
                     f"uid {resource_uid}") from err
+            self._current_state.resource = resource
+            self._current_state.datum = datum_doc
             handler = self._get_handler_maybe_cached(resource)
             error_to_raise = DataNotAccessible(
                     f"Filler was unable to load the data referenced by "
@@ -922,6 +924,8 @@ class Filler(DocumentRouter):
             filled_doc['filled'][key] = datum_id
         self._current_state.key = None
         self._current_state.descriptor = None
+        self._current_state.resource = None
+        self._current_state.datum = None
         return filled_doc
 
     def descriptor(self, doc):


### PR DESCRIPTION
The `filler_state` is a threadsafe way to side-band information into
"coersion" functions that, for example, return the data as a dask array.
We added this so that the functions could have access to `shape` via the
descriptor. In some cases we also need access to the resource to do that
successfully. In the future, when we support variable-length chunks, we
may also want access to the datum.

Prototyped and interactively tested against FXI data in
https://gist.github.com/danielballan/b4fccac29cd77e7bdfd93eba775d9b81