### PR TITLE
Projection configuration fix

### DIFF
--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -9,12 +9,13 @@
             "description": "Where to get the data from",
             "type": "object",
             "properties" : {
-                "type": {"type": "string", "enum": ["linked", "calculated", "static"], "description": "linked: a value linked from the data set, calculated: a value that requires calculation, static:  a value defined here in the projection "},
+                "type": {"enum": ["linked", "calculated", "static"], "description": "linked: a value linked from the data set, calculated: a value that requires calculation, static:  a value defined here in the projection "},
                 "stream": {"type": "string"},
                 "location": {"enum" : ["event", "configuration"], "description": "event comes from event, configuration comes from fields inthe run_start document"},
                 "field": {"type": "string"},
                 "calculation": {
                     "title" : "calculation properties",
+                    "description": "required fields if type is calculated",
                     "properties": {
                         "callable": {"type": "string", "description": "callable function to perform calculation"},
                         "args": {"type": "array", "decription": "args for calculation callable"},
@@ -23,6 +24,20 @@
                     "required": ["callable"]
                 }
             },
+            "anyOf":[
+                {
+                    "properties": {
+                        "type": {"const": "calculated"}
+                    },
+                    "required": ["calculation"]
+                },
+                {
+                    "properties": {
+                        "type": {"const": "linked"}
+                    },
+                    "required": ["location"]
+                }
+            ],
             "required" : ["type"],
             "additionalProperties": false
         },

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -13,6 +13,8 @@
                 "stream": {"type": "string"},
                 "location": {"enum" : ["start", "event", "configuration"], "description": "start comes from metadata fields in the start document, event comes from event, configuration comes from configuration fields in the event_descriptor document"},
                 "field": {"type": "string"},
+                "config_index": {"type": "integer"},
+                "config_device": {"type": "string"},
                 "calculation": {
                     "title" : "calculation properties",
                     "description": "required fields if type is calculated",
@@ -24,21 +26,23 @@
                     "required": ["callable"]
                 }
             },
-            "anyOf":[
+            "allOf": [
                 {
-                    "properties": {
-                        "type": {"const": "calculated"}
-                    },
-                    "required": ["calculation"]
+                    "if": {"properties": {"location": {"enum": "configuration"}}},
+                    "then": {"required": ["type", "config_index", "config_device", "field", "stream"]},
+                    "else": {"required" : ["type"]}
                 },
                 {
-                    "properties": {
-                        "type": {"const": "linked"}
-                    },
-                    "required": ["location"]
+                    "if": {"properties": {"location": {"enum": "event"}}},
+                    "then": {"required": ["type", "field", "stream"]},
+                    "else": {"required" : ["type"]}
+                },
+                {
+                    "if": {"properties": {"type": {"enum": "calculation"}}},
+                    "then": {"required": ["type", "field", "stream", "calculation"]},
+                    "else": {"required" : ["type"]}
                 }
-            ],
-            "required" : ["type"],
+            ],      
             "additionalProperties": false
         },
         "projections": {

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -24,28 +24,37 @@
                         "kwargs": {"type": "object", "description": "kwargs for calcalation callable"}
                     },
                     "required": ["callable"]
-                }
+                },
+                "value": {"description": "value explicitely defined in the projection when type==static."}
             },
             "allOf": [
                 {
-                    "if": {"properties": {"location": {"enum": "configuration"}}},
-                    "then": {"required": ["type", "config_index", "config_device", "field", "stream"]},
-                    "else": {"required" : ["type"]}
-                },
-                {
-                    "if": {"properties": {"location": {"enum": "event"}}},
-                    "then": {"required": ["type", "field", "stream"]},
-                    "else": {"required" : ["type"]}
+                    "if": {
+                        "allOf": [
+                            {"properties": {"location": {"enum": "configuration"}}},
+                            {"properties": {"type": {"enum": "linked"}}}
+                        ]},
+                    "then": {"required": ["type", "location", "config_index", "config_device", "field", "stream"]}
                 },
                 {
                     "if": {
-                        "allOf": [  
-                            {"properties": {"type": {"enum": "calculated"}}}, 
-                            {"properties": {"location": {"enum": "event"}}}
-                        ]
-                    },
-                    "then": {"required": ["type", "field", "stream",  "calculation"]},
-                    "else": {"required" : ["type"]}
+                        "allOf": [
+                            {"properties": {"location": {"enum": "event"}}},
+                            {"properties": {"type": {"enum": "linked"}}}
+                        ]},
+                    "then": {"required": ["type", "field", "stream"]}
+                },
+                {
+                    "if": {
+                        "allOf": [
+                            {"properties": {"location": {"enum": "event"}}},
+                            {"properties": {"type": {"enum": "calculated"}}}
+                        ]},
+                    "then": {"required": ["type", "field", "stream",  "calculation"]}
+                },
+                {
+                    "if": {"properties": {"type": {"enum": "static"}}},
+                    "then": {"required": ["type", "value"]}
                 }
             ],      
             "additionalProperties": false

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -42,7 +42,7 @@
                             {"properties": {"location": {"enum": "event"}}},
                             {"properties": {"type": {"enum": "linked"}}}
                         ]},
-                    "then": {"required": ["type", "field", "stream"]}
+                    "then": {"required": ["type", "location", "field", "stream"]}
                 },
                 {
                     "if": {

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -11,7 +11,7 @@
             "properties" : {
                 "type": {"enum": ["linked", "calculated", "static"], "description": "linked: a value linked from the data set, calculated: a value that requires calculation, static:  a value defined here in the projection "},
                 "stream": {"type": "string"},
-                "location": {"enum" : ["event", "configuration"], "description": "event comes from event, configuration comes from fields inthe run_start document"},
+                "location": {"enum" : ["start", "event", "configuration"], "description": "start comes from metadata fields in the start document, event comes from event, configuration comes from configuration fields in the event_descriptor document"},
                 "field": {"type": "string"},
                 "calculation": {
                     "title" : "calculation properties",

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -38,8 +38,13 @@
                     "else": {"required" : ["type"]}
                 },
                 {
-                    "if": {"properties": {"type": {"enum": "calculation"}}},
-                    "then": {"required": ["type", "field", "stream", "calculation"]},
+                    "if": {
+                        "allOf": [  
+                            {"properties": {"type": {"enum": "calculated"}}}, 
+                            {"properties": {"location": {"enum": "event"}}}
+                        ]
+                    },
+                    "then": {"required": ["type", "field", "stream",  "calculation"]},
                     "else": {"required" : ["type"]}
                 }
             ],      

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -19,17 +19,80 @@ def test_projection_schema(start):
     start["projections"] = valid_projections
     event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-    with pytest.raises(ValidationError):
-        start["projections"] = invalid_projections
+
+def test_bad_calc_field(start):
+    bad_calc_projections = [
+                # calc requires the calc fields
+                {
+                    "name": "test",
+                    "version": "42.0.0",
+                    "configuration": {},
+                    "projection": {
+                                "linked_field": {
+                                    "type": "calculated",
+                                    "location": "event",
+                                    "stream": "primary",
+                                    "field": "ccd",
+                                    }, }, }, ]
+
+    start["projections"] = bad_calc_projections
+    with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-    invalid_calc_projections = valid_projections.copy()
-    invalid_calc_projections[0]["projection"]["calc_field"] = {"linked_field": {
-                                                        "type": "linked",
-                                                        "location": "event",
-                                                        "stream": "primary",
-                                                        "field": "ccd",
-                                                        }}  # calc requires the calc fields
+
+def test_bad_configuration_field(start):
+    bad_configuration_projections = [
+                {
+                    "name": "test",
+                    "version": "42.0.0",
+                    "configuration": {},
+                    "projection": {
+                              "bad_config_field": {
+                                "type": "calculated",
+                                "location": "event",
+                                "config_index": 0,
+                                "config_device": "camera",
+                                "stream": "primary",
+                                # "field": "setting"
+                                }, }, }, ]
+
+    start["projections"] = bad_configuration_projections
+    with pytest.raises(ValidationError, ):
+        event_model.schema_validators[event_model.DocumentNames.start].validate(start)
+
+
+def test_bad_event_field(start):
+    bad_event_projections = [
+                {
+                    "name": "test",
+                    "version": "42.0.0",
+                    "configuration": {},
+                    "projection": {
+                                 "bad_event_field": {
+                                    "type": "linked",
+                                    "location": "event",
+                                    # "stream": "primary",
+                                    "field": "ccd",
+                                    }, }, }, ]
+    start["projections"] = bad_event_projections
+    with pytest.raises(ValidationError, ):
+        event_model.schema_validators[event_model.DocumentNames.start].validate(start)
+
+
+def test_bad_location_field(start):
+    bad_event_projections = [
+                {
+                    "name": "test",
+                    "version": "42.0.0",
+                    "configuration": {},
+                    "projection": {
+                                 "bad_event_field": {
+                                    "type": "linked",
+                                    "location": "event",
+                                    # "stream": "primary",
+                                    "field": "ccd",
+                                    }, }, }, ]
+    start["projections"] = bad_event_projections
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
@@ -67,18 +130,3 @@ valid_projections = [
                 },
             }
         ]
-
-invalid_projections = [
-                {
-                    "name": "test",
-                    "version": "42.0.0",
-                    "configuration": {},
-                    "projection": {
-                        "entry/instrument/detector/data": {
-                            "location": "THIS IS NOT VALID",
-                            "stream": "primary",
-                            "field": "ccd",
-                        },
-                    },
-                }
-            ]

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -6,6 +6,7 @@ import jsonschema
 
 skip_json_validations = LooseVersion(jsonschema.__version__) < LooseVersion('3.0.0')
 
+
 @pytest.fixture
 def start():
     run_bundle = event_model.compose_run()
@@ -42,6 +43,7 @@ def test_bad_calc_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
+
 @pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_configuration_field(start):
     bad_configuration_projections = [
@@ -62,6 +64,7 @@ def test_bad_configuration_field(start):
     start["projections"] = bad_configuration_projections
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
+
 
 @pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_event_field(start):

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -12,23 +12,23 @@ def start():
 def test_projection_in_start_doc():
     run_bundle = event_model.compose_run(uid="42", metadata={"projections": valid_projections})
     start_doc = run_bundle.start_doc
-    assert start_doc['projections'] == valid_projections
+    assert start_doc["projections"] == valid_projections
 
 
 def test_projection_schema(start):
-    start['projections'] = valid_projections
+    start["projections"] = valid_projections
     event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
     with pytest.raises(ValidationError):
-        start['projections'] = invalid_projections
+        start["projections"] = invalid_projections
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
     invalid_calc_projections = valid_projections.copy()
-    invalid_calc_projections[0]['projection']['calc_field'] = {'linked_field': {
-                                                        'type': 'linked',
-                                                        'location': 'event',
-                                                        'stream': 'primary',
-                                                        'field': 'ccd',
+    invalid_calc_projections[0]["projection"]["calc_field"] = {"linked_field": {
+                                                        "type": "linked",
+                                                        "location": "event",
+                                                        "stream": "primary",
+                                                        "field": "ccd",
                                                         }}  # calc requires the calc fields
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
@@ -40,18 +40,29 @@ valid_projections = [
                 "version": "42.0.0",
                 "configuration": {},
                 "projection": {
-                    'linked_field': {
-                        'type': 'linked',
-                        'location': 'event',
-                        'stream': 'primary',
-                        'field': 'ccd',
+                    "linked_field": {
+                        "type": "linked",
+                        "location": "event",
+                        "stream": "primary",
+                        "field": "ccd",
                     },
-                    'calc_field': {
-                        'type': 'calculated',
-                        'calculation': {
-                            'callable': 'pizza.order:slice',
-                            'kwargs': {'toppings': 'cheese'}
+                    "calc_field": {
+                        "type": "calculated",
+                        "location": "event",
+                        "field": "calc_field",
+                        "stream": "calc_stream",
+                        "calculation": {
+                            "callable": "pizza.order:slice",
+                            "kwargs": {"toppings": "cheese"}
                         }
+                    },
+                    "config_field": {
+                        "type": "linked",
+                        "location": "configuration",
+                        "config_index": 0,
+                        "config_device": "camera",
+                        "stream": "primary",
+                        "field": "setting"
                     }
                 },
             }
@@ -63,10 +74,10 @@ invalid_projections = [
                     "version": "42.0.0",
                     "configuration": {},
                     "projection": {
-                        'entry/instrument/detector/data': {
-                            'location': 'THIS IS NOT VALID',
-                            'stream': 'primary',
-                            'field': 'ccd',
+                        "entry/instrument/detector/data": {
+                            "location": "THIS IS NOT VALID",
+                            "stream": "primary",
+                            "field": "ccd",
                         },
                     },
                 }

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -1,7 +1,10 @@
+from distutils.version import LooseVersion
 import event_model
 import pytest
 from jsonschema.exceptions import ValidationError
+import jsonschema
 
+skip_json_validations = LooseVersion(jsonschema.__version__) < LooseVersion('3.0.0')
 
 @pytest.fixture
 def start():
@@ -19,7 +22,7 @@ def test_projection_schema(start):
     start["projections"] = valid_projections
     event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-
+@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_calc_field(start):
     bad_calc_projections = [
                 # calc requires the calc fields
@@ -39,7 +42,7 @@ def test_bad_calc_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-
+@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_configuration_field(start):
     bad_configuration_projections = [
                 {
@@ -60,7 +63,7 @@ def test_bad_configuration_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-
+@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_event_field(start):
     bad_event_projections = [
                 {

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -84,7 +84,7 @@ def test_bad_event_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-
+@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
 def test_bad_location_field(start):
     bad_event_projections = [
                 {

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -102,6 +102,24 @@ def test_bad_location_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
+@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+def test_bad_static_field(start):
+    bad_event_projections = [
+                {
+                    "name": "test",
+                    "version": "42.0.0",
+                    "configuration": {},
+                    "projection": {
+                                 "bad_event_field": {
+                                    "type": "static",
+                                    "location": "event",
+                                    # "stream": "primary",
+                                    "field": "ccd",
+                                    }, }, }, ]
+    start["projections"] = bad_event_projections
+    with pytest.raises(ValidationError, ):
+        event_model.schema_validators[event_model.DocumentNames.start].validate(start)
+
 
 valid_projections = [
             {
@@ -132,6 +150,10 @@ valid_projections = [
                         "config_device": "camera",
                         "stream": "primary",
                         "field": "setting"
+                    },
+                    "static_field": {
+                        "type": "static",
+                        "value": "strcvsdf"
                     }
                 },
             }

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -23,7 +23,9 @@ def test_projection_schema(start):
     start["projections"] = valid_projections
     event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+
+@pytest.mark.skipif(skip_json_validations,
+                    reason="projection schema uses draft7 conditions")
 def test_bad_calc_field(start):
     bad_calc_projections = [
                 # calc requires the calc fields
@@ -44,7 +46,8 @@ def test_bad_calc_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+@pytest.mark.skipif(skip_json_validations,
+                    reason="projection schema uses draft7 conditions")
 def test_bad_configuration_field(start):
     bad_configuration_projections = [
                 {
@@ -66,7 +69,8 @@ def test_bad_configuration_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+@pytest.mark.skipif(skip_json_validations,
+                    reason="projection schema uses draft7 conditions")
 def test_bad_event_field(start):
     bad_event_projections = [
                 {
@@ -84,7 +88,9 @@ def test_bad_event_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+
+@pytest.mark.skipif(skip_json_validations,
+                    reason="projection schema uses draft7 conditions")
 def test_bad_location_field(start):
     bad_event_projections = [
                 {
@@ -102,7 +108,9 @@ def test_bad_location_field(start):
     with pytest.raises(ValidationError, ):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
-@pytest.mark.skipif(skip_json_validations, reason="projection schema uses draft7 conditions")
+
+@pytest.mark.skipif(skip_json_validations,
+                    reason="projection schema uses draft7 conditions")
 def test_bad_static_field(start):
     bad_event_projections = [
                 {


### PR DESCRIPTION
Addresses an issue found that the projection schema does not have enough types.

## Description
The projection schema's "location" field contained "event" and "configuration". This PR adds "start". 

## Motivation and Context
The initial commits for projections and projectors contained the mistaken notion that the only two places in a docstream that might want to be projected are the start document and event fields. It was realized later that event descriptr configuration fields would also want to be project. This PR adds "start" to the projection location enum, and changes the meaning of "configuration" from the start document to the event descriptor.   Fixes

Additionally, fixes Fixes #183. This issue asked for more schema validation against calculated and liked fields. For example:

if type == calculated:
  calcuation field is also required
if type == linked:
  location field is also required


## How Has This Been Tested?
Tests in test_projections added for checking validation changes.


This PR will have  a corresponding PR in databroker.