### PR TITLE
Check for collisions in run router

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1282,6 +1282,20 @@ class RunRouter(DocumentRouter):
 
     def start(self, start_doc):
         uid = start_doc['uid']
+        # If we get the same uid twice, weird things will happen, so check for
+        # that and give a nice error message.
+        if uid in self._start_to_start_doc:
+            if self._start_to_start_doc[uid] == start_doc:
+                raise ValueError(
+                    "RunRouter received the same 'start' document twice:\n"
+                    "{start_doc!r}"
+                )
+            else:
+                raise ValueError(
+                    "RunRouter received two 'start' documents with different "
+                    "contents but the same uid:\n"
+                    "First: {self._start_to_start_doc[uid]!r}\n"
+                    "Second: {start_doc!r}")
         self._start_to_start_doc[uid] = start_doc
         filler = self.filler_class(self.handler_registry,
                                    root_map=self.root_map,

--- a/event_model/tests/test_run_router.py
+++ b/event_model/tests/test_run_router.py
@@ -243,3 +243,17 @@ def test_subfactory():
     rr("stop", stop_doc)
 
     assert len(rr._start_to_start_doc) == 0
+
+
+def test_same_start_doc_twice():
+    "If the user sends us the same uid twice, raise helpfully."
+    rr = event_model.RunRouter([])
+    doc = {'time': 0, 'uid': 'stuff'}
+    rr('start', doc)
+    with pytest.raises(ValueError):
+        rr('start', doc)  # exact same object
+    with pytest.raises(ValueError):
+        rr('start', doc.copy())  # same content
+    doc2 = {'time': 1, 'uid': 'stuff'}
+    with pytest.raises(ValueError):
+        rr('start', doc2)  # same uid, different content


### PR DESCRIPTION
While working on tests for https://github.com/bluesky/bluesky-live/pull/3 I accidentally fed `RunRouter` the same 'start' doc twice. It accepted it without complaint, leading to weird subsequent behavior that took me awhile to understand. This proactive collision-checking would have made the problem immediately clear.