### PR TITLE
Auth session field in start doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ target/
 #pycharm
 .idea/*
 
+#vscode
+.vscode/*
 
 #Ipython Notebook
 .ipynb_checkpoints

--- a/docs/source/data-model.rst
+++ b/docs/source/data-model.rst
@@ -115,7 +115,8 @@ A typical example
 .. code-block:: python
 
    # 'run start' document
-   {'detectors': ['random_walk:x'],
+   {'auth_session': ['bl42', 'proposal12345'],
+    'detectors': ['random_walk:x'],
     'hints': {'dimensions': [(['random_walk:dt'], 'primary')]},
     'motors': ('random_walk:dt',),
     'num_intervals': 2,

--- a/docs/source/data-model.rst
+++ b/docs/source/data-model.rst
@@ -115,7 +115,8 @@ A typical example
 .. code-block:: python
 
    # 'run start' document
-   {'auth_session': ['bl42', 'proposal12345'],
+   {'data_session': 'vist54321',
+    'data_groups': ['bl42', 'proposal12345'],
     'detectors': ['random_walk:x'],
     'hints': {'dimensions': [(['random_walk:dt'], 'primary')]},
     'motors': ('random_walk:dt',),

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -76,7 +76,7 @@
         }
     },
     "properties": {
-        "auth_session": {
+        "data_session": {
             "type": "array", "items": {"type": "string"},              
             "description": "An optional filtering field to associate runs with authorization/privilege frameworks"
         },

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -76,6 +76,10 @@
         }
     },
     "properties": {
+        "auth_session": {
+            "type": "array", "items": {"type": "string"},              
+            "description": "An optional filtering field to associate runs with authorization/privilege frameworks"
+        },
         "project": {
             "type": "string",
             "description": "Name of project that this run is part of"

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -77,8 +77,12 @@
     },
     "properties": {
         "data_session": {
+            "type": "string",              
+            "description": "An optional field for grouping runs. The meaning is not mandated, but this is a data management grouping and not a scientific grouping. It is intended to group runs in a visit or set of trials."
+        },
+        "data_groups": {
             "type": "array", "items": {"type": "string"},              
-            "description": "An optional filtering field to associate runs with authorization/privilege frameworks"
+            "description": "An optional list of data access groups that have meaning to some external system. Examples might include facility, beamline, end stations, proposal, safety form."
         },
         "project": {
             "type": "string",

--- a/event_model/tests/test_auth.py
+++ b/event_model/tests/test_auth.py
@@ -1,0 +1,12 @@
+import event_model
+import pytest
+from jsonschema.exceptions import ValidationError
+def test_auth_session():
+    run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": ['a', 'b']})
+    start_doc = run_bundle.start_doc
+    assert start_doc["auth_session"] == ['a', 'b']
+
+    with pytest.raises(ValidationError):
+        run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": 42})
+    with pytest.raises(ValidationError):
+        run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": {"a": "b"}})

--- a/event_model/tests/test_auth.py
+++ b/event_model/tests/test_auth.py
@@ -1,6 +1,8 @@
 import event_model
 import pytest
 from jsonschema.exceptions import ValidationError
+
+
 def test_auth_session():
     run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": ['a', 'b']})
     start_doc = run_bundle.start_doc

--- a/event_model/tests/test_auth.py
+++ b/event_model/tests/test_auth.py
@@ -4,11 +4,11 @@ from jsonschema.exceptions import ValidationError
 
 
 def test_auth_session():
-    run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": ['a', 'b']})
+    run_bundle = event_model.compose_run(uid="42", metadata={"data_session": ['a', 'b']})
     start_doc = run_bundle.start_doc
-    assert start_doc["auth_session"] == ['a', 'b']
+    assert start_doc["data_session"] == ['a', 'b']
 
     with pytest.raises(ValidationError):
-        run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": 42})
+        run_bundle = event_model.compose_run(uid="42", metadata={"data_session": 42})
     with pytest.raises(ValidationError):
-        run_bundle = event_model.compose_run(uid="42", metadata={"auth_session": {"a": "b"}})
+        run_bundle = event_model.compose_run(uid="42", metadata={"data_session": {"a": "b"}})

--- a/event_model/tests/test_auth.py
+++ b/event_model/tests/test_auth.py
@@ -3,12 +3,14 @@ import pytest
 from jsonschema.exceptions import ValidationError
 
 
-def test_auth_session():
-    run_bundle = event_model.compose_run(uid="42", metadata={"data_session": ['a', 'b']})
+def test_data_session():
+    run_bundle = event_model.compose_run(uid="42", metadata={"data_groups": ["a", "b"],
+                                                             "data_session": "magrathia_visit_42"})
     start_doc = run_bundle.start_doc
-    assert start_doc["data_session"] == ['a', 'b']
+    assert start_doc["data_groups"] == ['a', 'b']
 
     with pytest.raises(ValidationError):
-        run_bundle = event_model.compose_run(uid="42", metadata={"data_session": 42})
+        event_model.compose_run(uid="42", metadata={"data_session": ["shoud", "not", "be", "a", "list"]})
+
     with pytest.raises(ValidationError):
-        run_bundle = event_model.compose_run(uid="42", metadata={"data_session": {"a": "b"}})
+        event_model.compose_run(uid="42", metadata={"data_groups": "this should be an array"})


### PR DESCRIPTION
Adds auth_session field to start document schema

## Description
The optional auth_session field is intended to be a place to store filtering information that can be used by downstream systems when making decisions about authorization / privileges regarding the run.

## Motivation and Context
While this could be done by individual beamlines, it is desirable to make this part of the standard event model. The next step after this will be to go to the suitcase repos and index this field so that downstream processes can query it efficiently.

I made this a list of strings because the same run might have multiple known contexts. I had in mind "beamline A" and "proposal B" as distinct auth filtering contexts that could benefit.

## How Has This Been Tested?
New module test_auth.py includes tests for valid and invalid auth_sessions.
