### PR TITLE
Do not pin jsonschema in requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jsonschema>=3.0.0
+jsonschema
 numpy


### PR DESCRIPTION
Since we testing against jsonschema 2 and 3 in our CI, there is no need to pin to `>=3.0.0` in our requirements. Closes #193 