### PR TITLE
Accept any array-like.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1536,9 +1536,9 @@ for name, filename in SCHEMA_NAMES.items():
 if LooseVersion(jsonschema.__version__) >= LooseVersion("3.0.0"):
     def _is_array(checker, instance):
         return (
-            isinstance(instance, numpy.ndarray) or
             jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or
-            isinstance(instance, tuple)
+            isinstance(instance, tuple) or
+            hasattr(instance, "__array__")
         )
 
     _array_type_checker = jsonschema.validators.Draft7Validator.TYPE_CHECKER.redefine('array', _is_array)

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,9 +1,14 @@
+from distutils.version import LooseVersion
 import json
 import pickle
 
 import event_model
+import jsonschema
 import numpy
 import pytest
+
+
+JSONSCHEMA_2 = LooseVersion(jsonschema.__version__) < LooseVersion("3.0.0")
 
 
 def test_documents():
@@ -868,6 +873,7 @@ def test_pickle_filler():
     assert filler == deserialized
 
 
+@pytest.mark.skipif(JSONSCHEMA_2, reason="requres jsonschema >= 3")
 def test_array_like():
     "Accept any __array__-like as an array."
     dask_array = pytest.importorskip("dask.array")

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -866,3 +866,11 @@ def test_pickle_filler():
     serialized = pickle.dumps(filler)
     deserialized = pickle.loads(serialized)
     assert filler == deserialized
+
+
+def test_array_like():
+	"Accept any __array__-like as an array."
+	dask_array = pytest.importorskip("dask.array")
+	bundle = event_model.compose_run()
+	desc_bundle = bundle.compose_descriptor(data_keys={"a": {"shape": (3,), "dtype": "array", "source": ""}}, name="primary")
+	desc_bundle.compose_event_page(data={"a": dask_array.ones((5, 3))}, timestamps={"a": [1, 2, 3]}, seq_num=[1, 2, 3])

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -869,8 +869,15 @@ def test_pickle_filler():
 
 
 def test_array_like():
-	"Accept any __array__-like as an array."
-	dask_array = pytest.importorskip("dask.array")
-	bundle = event_model.compose_run()
-	desc_bundle = bundle.compose_descriptor(data_keys={"a": {"shape": (3,), "dtype": "array", "source": ""}}, name="primary")
-	desc_bundle.compose_event_page(data={"a": dask_array.ones((5, 3))}, timestamps={"a": [1, 2, 3]}, seq_num=[1, 2, 3])
+    "Accept any __array__-like as an array."
+    dask_array = pytest.importorskip("dask.array")
+    bundle = event_model.compose_run()
+    desc_bundle = bundle.compose_descriptor(
+        data_keys={"a": {"shape": (3,), "dtype": "array", "source": ""}},
+        name="primary"
+    )
+    desc_bundle.compose_event_page(
+        data={"a": dask_array.ones((5, 3))},
+        timestamps={"a": [1, 2, 3]},
+        seq_num=[1, 2, 3]
+    )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@
 # the documentation) but not necessarily required for _using_ it.
 codecov
 coverage
+dask[array]
 flake8
 pytest >3.9
 sphinx


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Accept anything that implements `__array__` as an array-like. 

## Motivation and Context
Specifically I want to be sure that we accept dask arrays when building things with `RunBuilder`, but this seems useful in general.

## How Has This Been Tested?
~Needs a test~
Wrote test, confirmed that it fails without the new fix.
<!--
## Screenshots (if appropriate):
-->
