### PR TITLE
ENH: make the start document to compose_resource optional

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1595,18 +1595,20 @@ def compose_datum_page(*, resource, counter, datum_kwargs, validate=True):
 default_path_semantics = {'posix': 'posix', 'nt': 'windows'}[os.name]
 
 
-def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
-                     path_semantics=default_path_semantics, uid=None, validate=True):
+def compose_resource(*, spec, root, resource_path, resource_kwargs,
+                     path_semantics=default_path_semantics, start=None, uid=None, validate=True):
     if uid is None:
         uid = str(uuid.uuid4())
     counter = itertools.count()
     doc = {'uid': uid,
-           'run_start': start['uid'],
            'spec': spec,
            'root': root,
            'resource_path': resource_path,
            'resource_kwargs': resource_kwargs,
            'path_semantics': path_semantics}
+    if start:
+        doc['run_start'] = start['uid']
+
     if validate:
         schema_validators[DocumentNames.resource].validate(doc)
 

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -887,3 +887,9 @@ def test_array_like():
         timestamps={"a": [1, 2, 3]},
         seq_num=[1, 2, 3]
     )
+
+
+def test_resource_start_optional():
+    event_model.compose_resource(
+        spec="TEST", root="/", resource_path="", resource_kwargs={}
+    )


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

 make the start document to compose_resource optional

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is to enable using these factories in ophyd objects that do not have
access to the start document.  We rely on the RunEngine to inject the correct
start uid on the way out.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
test added 

<!--
## Screenshots (if appropriate):
-->
