### PR TITLE
Fix for `databroker.v0` API

### DIFF
--- a/event_model/schemas/bulk_datum.json
+++ b/event_model/schemas/bulk_datum.json
@@ -1,6 +1,6 @@
 {
     "properties": {
-        "datum_kwargs_list": {
+        "datum_kwarg_list": {
             "type": "array",
             "items": {"type": "object"},
             "description": "Array of arguments to pass to the Handler to retrieve one quanta of data"
@@ -16,9 +16,9 @@
         }
     },
     "required": [
-        "datum_kwargs",
+        "datum_kwarg_list",
         "resource",
-        "datum_id"
+        "datum_ids"
     ],
     "additionalProperties": false,
     "type": "object",


### PR DESCRIPTION
Triggered by the recent work at ISS (see https://github.com/NSLS-II-ISS/profile_collection/compare/bulk_datum_test for the initial version, the newer one hasn't been pushed to GitHub yet).

Corresponding databroker API: https://github.com/bluesky/databroker/blob/970e9148dfab5e77101d40f059ecb30d064eac81/databroker/assets/mongo_core.py#L59-L60.