### PR TITLE
reserve time and seq_num keys

### DIFF
--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -97,7 +97,13 @@
                 },
                 "type": "object",
                 "description": "This describes the data in the Event Documents.",
-                "title": "data_keys"
+                "title": "data_keys",
+                "not": {
+                    "required": [
+                        "time",
+                        "seq_num"
+                    ]
+                }
             },
             "uid": {
                 "type": "string",


### PR DESCRIPTION
user-defined data_keys called "time" or "seq_num" conflict with with bluesky generated keys of the same name.