### PR TITLE
ENH: document status quo

### DIFF
--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -37,6 +37,10 @@
                     "source": {
                         "type": "string",
                         "description": "The source (ex piece of hardware) of the data."
+                    },
+                    "object_name": {
+                        "type": "string",
+                        "description": "The name of the object this key was pulled from."
                     }
                 },
                 "required": [


### PR DESCRIPTION
The RunEngine is injecting "object_name" into the data keys.  Document that we
are doing it with a named entry.