### PR TITLE
Use importlib.metadata to determine jsonschema version

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -9,6 +9,7 @@ import itertools
 import inspect
 import os
 from pkg_resources import resource_filename as rs_fn
+from importlib.metadata import version
 import threading
 import time as ttime
 import types
@@ -1531,11 +1532,10 @@ for name, filename in SCHEMA_NAMES.items():
     with open(rs_fn('event_model', filename)) as fin:
         schemas[name] = json.load(fin)
 
-
 # We pin jsonschema >=3.0.0 in requirements.txt but due to pip's dependency
 # resolution it is easy to end up with an environment where that pin is not
 # respected. Thus, we maintain best-effort support for 2.x.
-if LooseVersion(jsonschema.__version__) >= LooseVersion("3.0.0"):
+if LooseVersion(version(jsonschema)) >= LooseVersion("3.0.0"):
     def _is_array(checker, instance):
         return (
             jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or


### PR DESCRIPTION
Use `importlib.metadata` to determine `jsonschema` version. `event-model` contains some conditional logic depending on the version.

## Description
Pure refactor: no change in behaviour, this just uses a more up-to-date method of determining the version.

## Motivation and Context
The current method is deprecated and produces the following warning:
```shell
DeprecationWarning: Accessing jsonschema.__version__ is deprecated and will be removed in a future release. Use importlib.metadata directly to query for jsonschema's version.
```

## How Has This Been Tested?
TODO
