### PR TITLE
Use packaging.version instead of importlib.metadata.version

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -2,7 +2,6 @@ from collections import defaultdict, deque, namedtuple
 import collections.abc
 from dataclasses import dataclass
 from typing import Optional
-from distutils.version import LooseVersion
 import copy
 import json
 from enum import Enum
@@ -25,7 +24,10 @@ import numpy
 
 from ._version import get_versions
 
-
+if sys.version_info < (3, 8):
+    from importlib_metadata import metadata
+else:
+    from importlib.metadata import metadata
 
 __all__ = ['DocumentNames', 'schemas', 'schema_validators', 'compose_run']
 
@@ -1604,7 +1606,7 @@ for name, filename in SCHEMA_NAMES.items():
 # We pin jsonschema >=3.0.0 in requirements.txt but due to pip's dependency
 # resolution it is easy to end up with an environment where that pin is not
 # respected. Thus, we maintain best-effort support for 2.x.
-if LooseVersion(version("jsonschema")) >= LooseVersion("3.0.0"):
+if version.parse(metadata("jsonschema")["version"]) >= version.parse("3.0.0"):
     def _is_array(checker, instance):
         return (
             jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, 'array') or

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -18,16 +18,14 @@ import types
 import uuid
 import warnings
 import weakref
+from packaging import version
 
 import jsonschema
 import numpy
 
 from ._version import get_versions
 
-if sys.version_info < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
+
 
 __all__ = ['DocumentNames', 'schemas', 'schema_validators', 'compose_run']
 


### PR DESCRIPTION
Use packaging.version instead of importlib.metadata.version

## Description
Change the function used to determine the package version in response to a deprecation warning.

## Motivation and Context
 The distutils package has been deprecated for Python>=3.10 and will be removed in 3.12 per https://peps.python.org/pep-0632/
Now seeing the following when using event-model:
```shell
Traceback (most recent call last):
  File "/home/vid18871/projects/dodal/src/dodal/util.py", line 7, in <module>
    from bluesky.protocols import (
  File "/home/vid18871/projects/dodal/venv/lib64/python3.8/site-packages/bluesky/__init__.py", line 6, in <module>
    from .run_engine import RunEngine  # noqa: F401
  File "/home/vid18871/projects/dodal/venv/lib64/python3.8/site-packages/bluesky/run_engine.py", line 16, in <module>
    from .bundlers import RunBundler, maybe_await
  File "/home/vid18871/projects/dodal/venv/lib64/python3.8/site-packages/bluesky/bundlers.py", line 6, in <module>
    from event_model import DocumentNames
  File "/home/vid18871/projects/dodal/venv/lib64/python3.8/site-packages/event_model/__init__.py", line 1609, in <module>
    if LooseVersion(version("jsonschema")) >= LooseVersion("3.0.0"):
  File "/home/vid18871/projects/dodal/venv/lib64/python3.8/site-packages/setuptools/_distutils/version.py", line 55, in __init__
    warnings.warn(
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

## How Has This Been Tested?
TBC!
The docs build passes in CI, which validates the case for jsonschema>=3.0.0. I have tested locally with both the latest version and 2.6.0 for the other case.
