### PR TITLE
DOC: fix docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           deploy_key: ${{ secrets.ACTIONS_DOCUMENTATION_DEPLOY_KEY }}
           publish_branch: master
           publish_dir: ./docs/build/html
-          external_repository: bluesky/blueskyproject.io
+          external_repository: bluesky/bluesky.github.io
           destination_dir: ${{ env.REPOSITORY_NAME }}  # just the repo name, without the "bluesky/"
           keep_files: true
           force_orphan: false  # Keep git history.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix the docs publishing instructions as https://github.com/bluesky/blueskyproject.io does not exist. It's done via https://github.com/bluesky/bluesky.github.io (https://blueskyproject.io is pointing to https://bluesky.github.io).

```console
$ http bluesky.github.io
HTTP/1.1 301 Moved Permanently
Accept-Ranges: bytes
Age: 0
Connection: keep-alive
Content-Length: 162
Content-Type: text/html
Date: Thu, 06 Apr 2023 02:19:46 GMT
Location: https://blueskyproject.io/
Server: GitHub.com
Vary: Accept-Encoding
Via: 1.1 varnish
X-Cache: MISS
X-Cache-Hits: 0
X-Fastly-Request-ID: 729f87bea81e718b96a5d0cd317fed96b6b34b4b
X-GitHub-Request-Id: 5B76:05EC:1B2137:242E9F:642E2C42
X-Served-By: cache-ewr18148-EWR
X-Timer: S1680747586.263973,VS0,VE12
permissions-policy: interest-cohort=()

<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Failed CI job: https://github.com/bluesky/event-model/actions/runs/4619718976/jobs/8168834028.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No way to test before merging to master. Only hope.

<!--
## Screenshots (if appropriate):
-->
