### PR TITLE
Prevent validation errors in Start Document JSON Schema

### DIFF
--- a/event_model/schemas/bulk_events.json
+++ b/event_model/schemas/bulk_events.json
@@ -7,11 +7,11 @@
                 "properties": {
                     "data": {
                         "type": "object",
-                        "description": "The actual measument data"
+                        "description": "The actual measurement data"
                     },
                     "timestamps": {
                         "type": "object",
-                        "description": "The timestamps of the individual measument data"
+                        "description": "The timestamps of the individual measurement data"
                     },
                     "filled": {
                         "type": "object",

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -20,12 +20,12 @@
                     "description": "required fields if type is calculated",
                     "properties": {
                         "callable": {"type": "string", "description": "callable function to perform calculation"},
-                        "args": {"type": "array", "decription": "args for calculation callable"},
-                        "kwargs": {"type": "object", "description": "kwargs for calcalation callable"}
+                        "args": {"type": "array", "description": "args for calculation callable"},
+                        "kwargs": {"type": "object", "description": "kwargs for calculation callable"}
                     },
                     "required": ["callable"]
                 },
-                "value": {"description": "value explicitely defined in the projection when type==static."}
+                "value": {"description": "value explicitly defined in the projection when type==static."}
             },
             "allOf": [
                 {
@@ -60,7 +60,7 @@
             "additionalProperties": false
         },
         "projections": {
-            "title" : "Describe how to interperet this run as the given projection",
+            "title" : "Describe how to interpret this run as the given projection",
             "properties":{
                 "name": {"type": "string", "description": "The name of the projection"},
                 "version": {"type": "string", "description": "The version of the projection spec. Can specify the version of an external specification."},
@@ -160,5 +160,5 @@
         "time"
      ],
     "type": "object",
-    "description": "Document created at the start of run.  Provides a seach target and later documents link to it"
+    "description": "Document created at the start of run.  Provides a search target and later documents link to it"
 }

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -31,29 +31,29 @@
                 {
                     "if": {
                         "allOf": [
-                            {"properties": {"location": {"enum": "configuration"}}},
-                            {"properties": {"type": {"enum": "linked"}}}
+                            {"properties": {"location": {"enum": ["configuration"]}}},
+                            {"properties": {"type": {"enum": ["linked"]}}}
                         ]},
                     "then": {"required": ["type", "location", "config_index", "config_device", "field", "stream"]}
                 },
                 {
                     "if": {
                         "allOf": [
-                            {"properties": {"location": {"enum": "event"}}},
-                            {"properties": {"type": {"enum": "linked"}}}
+                            {"properties": {"location": {"enum": ["event"]}}},
+                            {"properties": {"type": {"enum": ["linked"]}}}
                         ]},
                     "then": {"required": ["type", "location", "field", "stream"]}
                 },
                 {
                     "if": {
                         "allOf": [
-                            {"properties": {"location": {"enum": "event"}}},
-                            {"properties": {"type": {"enum": "calculated"}}}
+                            {"properties": {"location": {"enum": ["event"]}}},
+                            {"properties": {"type": {"enum": ["calculated"]}}}
                         ]},
                     "then": {"required": ["type", "field", "stream",  "calculation"]}
                 },
                 {
-                    "if": {"properties": {"type": {"enum": "static"}}},
+                    "if": {"properties": {"type": {"enum": ["static"]}}},
                     "then": {"required": ["type", "value"]}
                 }
             ],      


### PR DESCRIPTION
## Description
Changes validation properties that are enums to define the enums as an array

## Motivation and Context
Current state is not valid Json Schema and causes exceptions when attempting to be ingested.
Alternative valid solution: `"enum": "value"` -> `"string" : "value"` (knowing that the potential value of the string comes from an enumeration) makes validation logic clearer to parse, but fails JsonSchema3 tests

## How Has This Been Tested?
Tested in an online JSON Schema linter, equivalent changes in use in AsyncAPI schema for BlueAPI (in progress)