### PR TITLE
Removed an off by one error

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1977,9 +1977,7 @@ def compose_stop(
         "run_start": start["uid"],
         "exit_status": exit_status,
         "reason": reason,
-        "num_events": {
-            k: v - 1 for k, v in event_counters.items() if k is not None and v != 1
-        },
+        "num_events": {k: v - 1 for k, v in event_counters.items() if k is not None},
     }
     if validate:
         schema_validators[DocumentNames.stop].validate(doc)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1977,7 +1977,9 @@ def compose_stop(
         "run_start": start["uid"],
         "exit_status": exit_status,
         "reason": reason,
-        "num_events": {k: v - 1 for k, v in event_counters.items()},
+        "num_events": {
+            k: v - 1 for k, v in event_counters.items() if k is not None and v != 1
+        },
     }
     if validate:
         schema_validators[DocumentNames.stop].validate(doc)
@@ -2127,6 +2129,7 @@ def compose_descriptor(
     if name not in streams:
         streams[name] = set(data_keys)
         event_counters[name] = 1
+
     return ComposeDescriptorBundle(
         doc,
         partial(compose_event, descriptor=doc, event_counters=event_counters),


### PR DESCRIPTION
Closes #259 

Fixes the problems mentioned in the above issue by 

* Filtering out `None` key descriptor and descriptors with only one element from the `num_events` in the `close_run` doc.