### PR TITLE
Use importlib resources instead of pkg_resources

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -15,6 +15,8 @@ from collections import defaultdict, deque, namedtuple
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
+from importlib.metadata import metadata
+from importlib.metadata import version as importlib_version
 from typing import (
     Any,
     Callable,
@@ -34,7 +36,6 @@ from typing import (
 import jsonschema
 import numpy
 from packaging import version
-from pkg_resources import resource_filename as rs_fn
 from typing_extensions import Literal
 
 from .documents.datum import Datum
@@ -53,12 +54,10 @@ from .documents.run_stop import RunStop
 from .documents.stream_datum import StreamDatum
 from .documents.stream_resource import StreamResource
 
-if sys.version_info < (3, 8):
-    from importlib_metadata import metadata
-    from importlib_metadata import version as importlib_version
+if sys.version_info < (3, 9):
+    import importlib_resources
 else:
-    from importlib.metadata import metadata
-    from importlib.metadata import version as importlib_version
+    import importlib.resources as importlib_resources
 
 __version__ = importlib_version("event-model")
 
@@ -1803,8 +1802,9 @@ SCHEMA_NAMES = {
 }
 schemas = {}
 for name, filename in SCHEMA_NAMES.items():
-    with open(rs_fn("event_model", filename)) as fin:
-        schemas[name] = json.load(fin)
+    ref = importlib_resources.files("event_model") / filename
+    with ref.open() as f:
+        schemas[name] = json.load(f)
 
 # We pin jsonschema >=3.0.0 in requirements.txt but due to pip's dependency
 # resolution it is easy to end up with an environment where that pin is not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 description = "Data model used by the bluesky ecosystem"
 dependencies = [
-    "importlib-metadata",
+    "importlib-resources",
     "jsonschema",
     "numpy",
     "packaging",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
replace `pkg_resources` with `importlib.resources`

Note that this introduces a dependency on the backport of importlib-resources, which could technically be a version gated dependency, but decided not to bother with that.

I also expired the (related) importlib-metadata python version gating, as that was only in python < 3.8, which is no longer supported anyway, and thus is unreachable

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Setuptools is removing `pkg_resources`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->

Standard pytest passes, no longer imports pkg_resources
