### PR TITLE
Allow descriptor units to be null

### DIFF
--- a/event_model/documents/event_descriptor.py
+++ b/event_model/documents/event_descriptor.py
@@ -97,7 +97,8 @@ EVENT_DESCRIPTOR_EXTRA_SCHEMA = {
             "title": "DataType",
             "patternProperties": {"^([^./]+)$": {"$ref": "#/definitions/DataType"}},
             "additionalProperties": False,
-        }
+        },
+        "DataKey": {"properties": {"units": {"type": ["string", "null"]}}},
     },
     "additionalProperties": False,
 }

--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -84,7 +84,10 @@
             "units": {
                "title": "Units",
                "description": "Engineering units of the value",
-               "type": "string"
+               "type": [
+                  "string",
+                  "null"
+               ]
             }
          },
          "required": [

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -59,7 +59,7 @@ def test_compose_run():
     assert bundle.compose_stop is compose_stop
     bundle = compose_descriptor(
         data_keys={
-            "motor": {"shape": [], "dtype": "number", "source": "..."},
+            "motor": {"shape": [], "dtype": "number", "source": "...", "units": None},
             "image": {
                 "shape": [512, 512],
                 "dtype": "number",


### PR DESCRIPTION
## Description
Ophyd v1 sets units to be strings if the exist, and null if they do not. Allow this in the schema and add into the test

## Motivation and Context
1.19.3 breaks Ophyd v1 Devices with null units

## How Has This Been Tested?
With the added test, and by running the ophyd v2 docs build which uses one such Device
