### PR TITLE
Specified pydantic <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
     "numpydoc",
 
     # For schema generation.
-    "pydantic",
+    "pydantic<2.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Forces pydantic < 2.0 - the schema generation code doesn't work with pydantic 2.0 changes.
