### PR TITLE
Find schema files relative to source code, this allows tests to be ru…

### DIFF
--- a/event_model/tests/test_schema_generation.py
+++ b/event_model/tests/test_schema_generation.py
@@ -9,7 +9,7 @@ if sys.version_info[:2] >= (3, 9):
     import json
     import os
 
-    from event_model import SCHEMA_PATH
+    import event_model
     from event_model.documents import (
         Datum,
         DatumPage,
@@ -39,7 +39,7 @@ if sys.version_info[:2] >= (3, 9):
         StreamResource,
     ]
 
-    SCHEMA_PATH = "event_model/" + SCHEMA_PATH
+    SCHEMA_PATH = event_model.__path__[0] + '/schemas/'
 
     @pytest.mark.parametrize("typed_dict_class", typed_dict_class_list)
     def test_generated_json_matches_typed_dict(typed_dict_class, tmpdir):

--- a/event_model/tests/test_schema_generation.py
+++ b/event_model/tests/test_schema_generation.py
@@ -39,7 +39,7 @@ if sys.version_info[:2] >= (3, 9):
         StreamResource,
     ]
 
-    SCHEMA_PATH = event_model.__path__[0] + '/schemas/'
+    SCHEMA_PATH = event_model.__path__[0] + "/schemas/"
 
     @pytest.mark.parametrize("typed_dict_class", typed_dict_class_list)
     def test_generated_json_matches_typed_dict(typed_dict_class, tmpdir):


### PR DESCRIPTION
…n from any directory. As this is a test, I think a little hack like this is fine. Going forward, I would remove SCHEMA_PATH from the API, and if it is used, replace it with a thin wrapper around importlib.resources

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
