### PR TITLE
Mnt py312

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 env:
   # The target python version, which must match the Dockerfile version
-  CONTAINER_PYTHON: "3.11"
+  CONTAINER_PYTHON: "3.12"
 
 jobs:
   lint:
@@ -32,8 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python: ["3.9", "3.10", "3.11"]
-        jsonschema: [2, 3]
+        python: ["3.9", "3.10", "3.11", "3.12"]
 
         install: ["-e .[dev]"]
         # Make one version be non-editable to test both paths of version code
@@ -59,7 +58,6 @@ jobs:
         uses: ./.github/actions/install_requirements
         with:
           python_version: ${{ matrix.python }}
-          jsonschema_version: ${{ matrix.jsonschema }}
           requirements_file: requirements-test-${{ matrix.os }}-${{matrix.python }}-${{ matrix.jsonschema }}.txt
           install_options: ${{ matrix.install }}
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1808,9 +1808,7 @@ for name, filename in SCHEMA_NAMES.items():
 
 def _is_array(checker, instance):
     return (
-        jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(
-            instance, "array"
-        )
+        jsonschema.validators.Draft7Validator.TYPE_CHECKER.is_type(instance, "array")
         or isinstance(instance, tuple)
         or hasattr(instance, "__array__")
     )

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -7,15 +7,12 @@ import os
 import sys
 import threading
 import time as ttime
-import types
 import uuid
 import warnings
 import weakref
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from enum import Enum
-from functools import partial
-from importlib.metadata import metadata
 from importlib.metadata import version as importlib_version
 from typing import (
     Any,

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,14 +1,11 @@
 import json
 import pickle
-from packaging.version import parse
 
 import jsonschema
 import numpy
 import pytest
 
 import event_model
-
-JSONSCHEMA_2 = parse(jsonschema.__version__) < parse("3.0.0")
 
 
 def test_documents():
@@ -1030,7 +1027,6 @@ def test_pickle_filler():
     assert filler == deserialized
 
 
-@pytest.mark.skipif(JSONSCHEMA_2, reason="requres jsonschema >= 3")
 def test_array_like():
     "Accept any __array__-like as an array."
     dask_array = pytest.importorskip("dask.array")

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,7 +1,6 @@
 import json
 import pickle
 
-import jsonschema
 import numpy
 import pytest
 

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1,6 +1,6 @@
 import json
 import pickle
-from distutils.version import LooseVersion
+from packaging.version import parse
 
 import jsonschema
 import numpy
@@ -8,7 +8,7 @@ import pytest
 
 import event_model
 
-JSONSCHEMA_2 = LooseVersion(jsonschema.__version__) < LooseVersion("3.0.0")
+JSONSCHEMA_2 = parse(jsonschema.__version__) < parse("3.0.0")
 
 
 def test_documents():

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -1,11 +1,8 @@
 import jsonschema
-from packaging.version import parse
 import pytest
 from jsonschema.exceptions import ValidationError
 
 import event_model
-
-skip_json_validations = parse(jsonschema.__version__) < parse("3.0.0")
 
 
 @pytest.fixture
@@ -27,9 +24,6 @@ def test_projection_schema(start):
     event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(
-    skip_json_validations, reason="projection schema uses draft7 conditions"
-)
 def test_bad_calc_field(start):
     bad_calc_projections = [
         # calc requires the calc fields
@@ -55,9 +49,6 @@ def test_bad_calc_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(
-    skip_json_validations, reason="projection schema uses draft7 conditions"
-)
 def test_bad_configuration_field(start):
     bad_configuration_projections = [
         {
@@ -84,9 +75,6 @@ def test_bad_configuration_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(
-    skip_json_validations, reason="projection schema uses draft7 conditions"
-)
 def test_bad_event_field(start):
     bad_event_projections = [
         {
@@ -110,9 +98,6 @@ def test_bad_event_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(
-    skip_json_validations, reason="projection schema uses draft7 conditions"
-)
 def test_bad_location_field(start):
     bad_event_projections = [
         {
@@ -136,9 +121,6 @@ def test_bad_location_field(start):
         event_model.schema_validators[event_model.DocumentNames.start].validate(start)
 
 
-@pytest.mark.skipif(
-    skip_json_validations, reason="projection schema uses draft7 conditions"
-)
 def test_bad_static_field(start):
     bad_event_projections = [
         {

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -1,12 +1,11 @@
-from distutils.version import LooseVersion
-
 import jsonschema
+from packaging.version import parse
 import pytest
 from jsonschema.exceptions import ValidationError
 
 import event_model
 
-skip_json_validations = LooseVersion(jsonschema.__version__) < LooseVersion("3.0.0")
+skip_json_validations = parse(jsonschema.__version__) < parse("3.0.0")
 
 
 @pytest.fixture

--- a/event_model/tests/test_projections.py
+++ b/event_model/tests/test_projections.py
@@ -1,4 +1,3 @@
-import jsonschema
 import pytest
 from jsonschema.exceptions import ValidationError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,8 @@ classifiers = [
 description = "Data model used by the bluesky ecosystem"
 dependencies = [
     "importlib-resources",
-    "jsonschema",
+    "jsonschema>=3",
     "numpy",
-    "packaging",
     "typing_extensions"
 ]
 dynamic = ["version"]
@@ -33,7 +32,6 @@ dev = [
     "flake8",
     "flake8-isort",
     "Flake8-pyproject",
-    "packaging",
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "flake8",
     "flake8-isort",
     "Flake8-pyproject",
+    "packaging",
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
@@ -117,8 +118,8 @@ skipsdist=True
 # Don't create a virtualenv for the command, requires tox-direct plugin
 direct = True
 passenv = *
-allowlist_externals = 
-    pytest 
+allowlist_externals =
+    pytest
     pre-commit
     mypy
     sphinx-build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 description = "Data model used by the bluesky ecosystem"
 dependencies = [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Drop support for old jsonschema (to drop need to parse version strings)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Looking at https://github.com/conda-forge/event-model-feedstock/pull/46 the failures are because our tests use `distutils` which were removed in py312.  The first commit changes to use `packgaing.version.parse` instead.  However, we only need to check version strings to support jsonschema < 3 which at this point is almost 5 years old so I think we can safely require a newer version of `jsonschema`.

If changing the dep pinning in too aggressive I can drop the second commit.

attn @ZLLentz 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
## Screenshots (if appropriate):
-->
