### PR TITLE
Fix minor bug in event_model's rechunk_event_pages

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -2772,7 +2772,7 @@ def rechunk_event_pages(event_pages: Iterable, chunk_size: int) -> Generator:
                     for key in page["timestamps"].keys()
                 },
                 "filled": {
-                    key: page["filled"][key][start:stop] for key in page["data"].keys()
+                    key: page["filled"][key][start:stop] for key in page["filled"].keys()
                 },
             }
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -2831,7 +2831,7 @@ def merge_event_pages(event_pages: Iterable[EventPage]) -> EventPage:
             key: list(
                 itertools.chain.from_iterable([page["filled"][key] for page in pages])
             )
-            for key in pages[0]["data"].keys()
+            for key in pages[0]["filled"].keys()
         },
     )
     return cast(EventPage, doc)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -2765,8 +2765,7 @@ def rechunk_event_pages(event_pages: Iterable, chunk_size: int) -> Generator:
                 "descriptor": page["descriptor"],
                 **{key: page[key][start:stop] for key in array_keys},
                 "data": {
-                    key: page["data"][key][start:stop]
-                    for key in page["data"].keys()
+                    key: page["data"][key][start:stop] for key in page["data"].keys()
                 },
                 "timestamps": {
                     key: page["timestamps"][key][start:stop]

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -2765,14 +2765,16 @@ def rechunk_event_pages(event_pages: Iterable, chunk_size: int) -> Generator:
                 "descriptor": page["descriptor"],
                 **{key: page[key][start:stop] for key in array_keys},
                 "data": {
-                    key: page["data"][key][start:stop] for key in page["data"].keys()
+                    key: page["data"][key][start:stop]
+                    for key in page["data"].keys()
                 },
                 "timestamps": {
                     key: page["timestamps"][key][start:stop]
                     for key in page["timestamps"].keys()
                 },
                 "filled": {
-                    key: page["filled"][key][start:stop] for key in page["filled"].keys()
+                    key: page["filled"][key][start:stop]
+                    for key in page["filled"].keys()
                 },
             }
 

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -838,7 +838,8 @@ def test_single_run_document_router():
         sr("descriptor", desc_bundle.descriptor_doc)
 
 
-def test_rechunk_event_pages():
+@pytest.mark.parametrize("filled", [True, False])
+def test_rechunk_event_pages(filled):
     def event_page_gen(page_size, num_pages):
         """
         Generator event_pages for testing.
@@ -851,7 +852,7 @@ def test_rechunk_event_pages():
                 **{key: list(range(page_size)) for key in array_keys},
                 "data": {key: list(range(page_size)) for key in data_keys},
                 "timestamps": {key: list(range(page_size)) for key in data_keys},
-                "filled": {key: list(range(page_size)) for key in data_keys},
+                "filled": {key: list(range(page_size)) for key in data_keys if filled},
             }
 
     # Get a list of event pages of size 13.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
`rechunk_event_pages` has a bug if you try to re-chunk an EventPage that has an empty "filled" key, because the dictionary comprehension to create the new "filled" dictionaries uses keys from "data". This means that you can't rechunk the EventPages that are emitted by the RunEngine.

## Description
<!--- Describe your changes in detail -->
I have just changed one word -- instead of 
`"filled": {key: page["filled"][key][start:stop] for key in page["data"].keys()},`
I have written
`"filled": {key: page["filled"][key][start:stop] for key in page["filled"].keys()},`
which correctly leaves filled empty, if it was empty to begin with.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is necessary to fix this bug in order to re-chunk EventPages that are currently too large to go into Kafka after long fly-scans.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this by manually calling rechunk_event_pages on some generated EventPages, and also by running the built-in tests.