### PR TITLE
DOC: Fix the switcher URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -198,7 +198,7 @@ texinfo_documents = [
 html_theme = "pydata_sphinx_theme"
 github_repo = project
 github_user = "bluesky"
-switcher_json = f"https://{github_user}.github.io/{github_repo}/switcher.json"
+switcher_json = f"https://blueskyproject.io/{github_repo}/switcher.json"
 switcher_exists = requests.get(switcher_json).ok
 if not switcher_exists:
     print(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The URL brought over from the Copier project was too generic for us. I've changed it to point to the right place.

This fixes both the version switcher and the search box.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #304  so that now both the search and version switching features work

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local testing shows the built docs now have a functional search box and can switch versions.
<!--
## Screenshots (if appropriate):
-->
