### PR TITLE
ENH: Added NX_class as a PerObjectHint to the event descriptor.

### DIFF
--- a/event_model/documents/event_descriptor.py
+++ b/event_model/documents/event_descriptor.py
@@ -69,6 +69,15 @@ class PerObjectHint(TypedDict):
             Field(description="The 'interesting' data keys for this device."),
         ]
     ]
+    NX_class: NotRequired[
+        Annotated[
+            str,
+            Field(
+                description="The NeXus class definition for this device.",
+                pattern=r"^NX[A-Za-z_]+$",
+            ),
+        ]
+    ]
 
 
 class Configuration(TypedDict):

--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -112,6 +112,12 @@
             "description": "The 'interesting' data keys for this device.",
             "type": "object",
             "properties": {
+                "NX_class": {
+                    "title": "Nx Class",
+                    "description": "The NeXus class definition for this device.",
+                    "type": "string",
+                    "pattern": "^NX[A-Za-z_]+$"
+                },
                 "fields": {
                     "title": "Fields",
                     "description": "The 'interesting' data keys for this device.",


### PR DESCRIPTION
This is an optional hint that can be used to carry a NeXus class definition one may wish to associate with a device.

## Motivation and Context
It would be good to have a standard way to assign a NeXus class definition to a high level device. Having a specific field with a standard name will better allow the community to converge on a standard way to assign and use this definition for high level processes such as writing callbacks.