### PR TITLE
Add `dtype_numpy` with medium-effort validation

### DIFF
--- a/event_model/documents/event_descriptor.py
+++ b/event_model/documents/event_descriptor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from typing_extensions import Annotated, Literal, NotRequired, TypedDict
 
@@ -21,7 +21,20 @@ class DataKey(TypedDict):
     ]
     dtype: Annotated[
         Dtype,
-        Field(description="The type of the data in the event."),
+        Field(description="The type of the data in the event, given as a broad JSON schema type."),
+    ]
+    dtype_numpy: NotRequired[
+        Annotated[
+            Union[
+                str,  # e.g. "<u4",
+                List[Tuple[str, str]],  # e.g. [("a", "<u4"), ("b", "<f8")]
+            ],
+            Field(
+                description="The type of the data in the event, given as a numpy dtype string (or, for structured dtypes, array)",
+                pattern="[|<>][tbiufcmMOSUV][0-9]+",
+            ),
+            # TODO Enforce the regex pattern.
+        ]
     ]
     external: NotRequired[
         Annotated[

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -1021,3 +1021,48 @@ def test_resource_start_optional():
     event_model.compose_resource(
         spec="TEST", root="/", resource_path="", resource_kwargs={}
     )
+
+
+def test_dtype_numpy():
+    "Test schema validation for various values for dtype_numpy."
+    bundle = event_model.compose_run()
+    start_doc, compose_descriptor, compose_resource, compose_stop = bundle
+    assert bundle.start_doc is start_doc
+    assert bundle.compose_descriptor is compose_descriptor
+    assert bundle.compose_resource is compose_resource
+    assert bundle.compose_stop is compose_stop
+    compose_descriptor(
+        data_keys={
+            "image": {
+                "shape": [512, 512],
+                "dtype": "number",
+                "source": "...",
+                "external": "FILESTORE:",
+            },
+        },
+        name="missing_dtype_numpy",
+    )
+    compose_descriptor(
+        data_keys={
+            "image": {
+                "shape": [512, 512],
+                "dtype": "number",
+                "dtype_numpy": "<u8",
+                "source": "...",
+                "external": "FILESTORE:",
+            },
+        },
+        name="basic_dtype_numpy",
+    )
+    compose_descriptor(
+        data_keys={
+            "image": {
+                "shape": [512, 512],
+                "dtype": "number",
+                "dtype_numpy": [("a", "<u8"), ("b", "<f8")],
+                "source": "...",
+                "external": "FILESTORE:",
+            },
+        },
+        name="structured_dtype_numpy",
+    )


### PR DESCRIPTION
Add `dtype_numpy` to Event Descriptor.

Supersedes #215.