### PR TITLE
added `types-requests` to fix linting CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "sphinx-design",
     "tox-direct",
     "types-mock",
+    "types-requests",
 
     # These are dependencies of various sphinx extensions for documentation.
     "ipython",


### PR DESCRIPTION
We needed a new type stubs package to make mypy happy in pre-commit.

Happy to release this as a patch.