### PR TITLE
Allow additional fields in RunStart and EventDescriptor TypedDict

### DIFF
--- a/src/event_model/documents/event_descriptor.py
+++ b/src/event_model/documents/event_descriptor.py
@@ -156,7 +156,7 @@ class Configuration(TypedDict):
     """
 
 
-class EventDescriptor(TypedDict):
+class EventDescriptor(TypedDict, total=False):
     """
     Document to describe the data captured in the associated event
     documents

--- a/src/event_model/documents/run_start.py
+++ b/src/event_model/documents/run_start.py
@@ -119,7 +119,7 @@ class Projections(TypedDict):
     """
 
 
-class RunStart(TypedDict):
+class RunStart(TypedDict, total=False):
     """
     Document created at the start of run. Provides a seach target and
     later documents link to it

--- a/src/event_model/generate/templates/TypedDict.jinja2
+++ b/src/event_model/generate/templates/TypedDict.jinja2
@@ -1,0 +1,5 @@
+{%- if is_functional_syntax %}
+{% include 'TypedDictFunction.jinja2' %}
+{%- else %}
+{% include 'TypedDictClass.jinja2' %}
+{%- endif %}

--- a/src/event_model/generate/templates/TypedDictClass.jinja2
+++ b/src/event_model/generate/templates/TypedDictClass.jinja2
@@ -1,0 +1,17 @@
+class {{ class_name }}({{ base_class }}{% if class_name in ["RunStart", "EventDescriptor"] %}, total=False{% endif %}):
+{%- if description %}
+    """
+    {{ description | indent(4) }}
+    """
+{%- endif %}
+{%- if not fields and not description %}
+    pass
+{%- endif %}
+{%- for field in fields %}
+    {{ field.name }}: {{ field.type_hint }}
+    {%- if field.docstring %}
+    """
+    {{ field.docstring | indent(4) }}
+    """
+    {%- endif %}
+{%- endfor -%}

--- a/src/event_model/generate/templates/TypedDictFunction.jinja2
+++ b/src/event_model/generate/templates/TypedDictFunction.jinja2
@@ -1,0 +1,15 @@
+{%- if description %}
+"""
+{{ description | indent(4) }}
+"""
+{%- endif %}
+{{ class_name }} = TypedDict('{{ class_name }}', {
+{%- for field in all_fields %}
+    '{{ field.key }}': {{ field.type_hint }},
+    {%- if field.docstring %}
+    """
+    {{ field.docstring | indent(4) }}
+    """
+    {%- endif %}
+{%- endfor -%}
+})


### PR DESCRIPTION
Pointed out by @callumforrester and @abbiemery 