### PR TITLE
Allow None in descriptor shape

### DIFF
--- a/src/event_model/basemodels/event_descriptor.py
+++ b/src/event_model/basemodels/event_descriptor.py
@@ -186,8 +186,11 @@ class DataKey(BaseModel):
         ),
     ]
     shape: Annotated[
-        List[int],
-        Field(description="The shape of the data.  Empty list indicates scalar data."),
+        List[Optional[int]],
+        Field(
+            description="The shape of the data.  Empty list indicates scalar data. "
+            "None indicates a dimension with unknown length."
+        ),
     ]
     source: Annotated[
         str, Field(description="The source (ex piece of hardware) of the data.")

--- a/src/event_model/documents/event_descriptor.py
+++ b/src/event_model/documents/event_descriptor.py
@@ -127,9 +127,9 @@ class DataKey(TypedDict):
     """
     Number of digits after decimal place if a floating point number
     """
-    shape: List[int]
+    shape: List[Optional[int]]
     """
-    The shape of the data.  Empty list indicates scalar data.
+    The shape of the data.  Empty list indicates scalar data. None indicates a dimension with unknown length.
     """
     source: str
     """

--- a/src/event_model/schemas/event_descriptor.json
+++ b/src/event_model/schemas/event_descriptor.json
@@ -122,10 +122,17 @@
                 },
                 "shape": {
                     "title": "shape",
-                    "description": "The shape of the data.  Empty list indicates scalar data.",
+                    "description": "The shape of the data.  Empty list indicates scalar data. None indicates a dimension with unknown length.",
                     "type": "array",
                     "items": {
-                        "type": "integer"
+                        "anyOf": [
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 },
                 "source": {


### PR DESCRIPTION
## Description

Closes https://github.com/bluesky/event-model/issues/351

Allow `None` as a shape in `event-model` - a dimension with extent `None` is interpreted as a dimension of unknown shape.

## Motivation and Context

Fixes https://github.com/bluesky/event-model/issues/351

One scientific motivation for this is event-mode data, common at neutron facilities, where a detector records the position and timestamp of each detection event individually. This means that event-mode detectors conceptually give an array of variable shape each time data is acquired from them, where the dimensionality corresponds to the number of detection events.

## How Has This Been Tested?

Tested that the `RunEngine` now _accepts_ emitting descriptors with a declared shape of `(None, )`.

At the moment not all downstream consumers are able to process these events - further work will be required to support this. For example the `TiledWriter` in bluesky does not currently handle this.

This change should be backwards-compatible with all existing data, as it is a loosening of the schema.
