### PR TITLE
Pin pydantic to <2.11, newer versions not supported on Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "numpydoc",
 
   # For schema generation.
-  "pydantic<3",
+  "pydantic<2.11",
   "datamodel-code-generator",
 ]
 


### PR DESCRIPTION
## Description

Pin `pydantic<2.11` (dev dependency only)

Pydantic 2.11 is not supported on Python 3.8, which leads to different schema generation on 3.8 versus later versions. Force all the python versions to pick up the same pydantic version.

The other option would be to drop Python 3.8 support in this repo - bluesky itself no longer supports 3.8, do other uses of `event-model` still need it?

## Motivation and Context

At the moment it is not possible to create a PR which passes both the 3.8 build and >3.8 builds

## How Has This Been Tested?

CI builds
