### PR TITLE
ENH: generate `Document` union type

### DIFF
--- a/src/event_model/basemodels/__init__.py
+++ b/src/event_model/basemodels/__init__.py
@@ -29,6 +29,19 @@ DocumentType = Union[
     Type[StreamResource],
 ]
 
+Document = Union[
+    Datum,
+    DatumPage,
+    Event,
+    EventDescriptor,
+    EventPage,
+    Resource,
+    RunStart,
+    RunStop,
+    StreamDatum,
+    StreamResource,
+]
+
 ALL_BASEMODELS: Tuple[DocumentType, ...] = (
     Datum,
     DatumPage,

--- a/src/event_model/documents/__init__.py
+++ b/src/event_model/documents/__init__.py
@@ -26,6 +26,19 @@ DocumentType = Union[
     Type[StreamResource],  # noqa: F405,
 ]
 
+Document = Union[
+    Datum,  # noqa: F405
+    DatumPage,  # noqa: F405
+    Event,  # noqa: F405
+    EventDescriptor,  # noqa: F405
+    EventPage,  # noqa: F405
+    Resource,  # noqa: F405
+    RunStart,  # noqa: F405
+    RunStop,  # noqa: F405
+    StreamDatum,  # noqa: F405
+    StreamResource,  # noqa: F405
+]
+
 ALL_DOCUMENTS: Tuple[DocumentType, ...] = (
     Datum,  # noqa: F405
     DatumPage,  # noqa: F405

--- a/src/event_model/generate/create_documents.py
+++ b/src/event_model/generate/create_documents.py
@@ -209,8 +209,12 @@ from typing import Tuple, Type, Union
 {2}
 ]
 
-ALL_{3}: Tuple[{1}Type, ...] = (
-{4}
+{1} = Union[
+{3}
+]
+
+ALL_{4}: Tuple[{1}Type, ...] = (
+{5}
 )"""
 
 
@@ -243,16 +247,21 @@ def generate_init_py(output_root: Path):
         ]
     )
 
+    documents = "\n".join(
+        [f"    {class_name},  # noqa: F405" for class_name in document_class_names]
+    )
+
     all_documents = "\n".join(
         [f"    {class_name},  # noqa: F405" for class_name in document_class_names]
     )
 
     init_py = GENERATED_INIT_PY.format(
-        init_py_imports,
-        output_root.name.rstrip("s").title(),
-        document_types,
-        output_root.name.upper(),
-        all_documents,
+        init_py_imports, # 0
+        output_root.name.rstrip("s").title(), # 1
+        document_types, # 2
+        documents, # 3
+        output_root.name.upper(), # 4
+        all_documents, # 5
     )
 
     with open(output_root / "__init__.py", "w") as f:

--- a/src/event_model/generate/create_documents.py
+++ b/src/event_model/generate/create_documents.py
@@ -256,12 +256,12 @@ def generate_init_py(output_root: Path):
     )
 
     init_py = GENERATED_INIT_PY.format(
-        init_py_imports, # 0
-        output_root.name.rstrip("s").title(), # 1
-        document_types, # 2
-        documents, # 3
-        output_root.name.upper(), # 4
-        all_documents, # 5
+        init_py_imports,
+        output_root.name.rstrip("s").title(),
+        document_types,
+        documents,
+        output_root.name.upper(),
+        all_documents,
     )
 
     with open(output_root / "__init__.py", "w") as f:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a `Document` union type; differently from `DocumentType`, this type union is for type checking instances of document objects rather than their class type.

I simply reshuffled a bit the `GENERATED_INIT_PY` template to keep the original `DocumentType` intact.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was trying to type hinting a callback function that should accept all possible documents and realized that `DocumentType` wasn't fit for the purpose.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally via `pytest`.

<!--
## Screenshots (if appropriate):
-->
