### PR TITLE
ENH: drop python 3.8, 3.9 and support 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest"] # can add windows-latest, macos-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/docs/reference/release-history.rst
+++ b/docs/reference/release-history.rst
@@ -2,6 +2,19 @@
 Release History
 ***************
 
+Unreleased (2025-??-??)
+=======================
+
+Changed
+-------
+
+* Drop support for Python 3.8 and 3.9.
+
+Added
+-----
+
+* Add support for Python 3.13.
+
 v1.23.1 (2025-08-28)
 ====================
 
@@ -182,7 +195,7 @@ Changed
 -------
 
 * The package requirements have been relaxed to accept jsonschema versions 2 or
-  3. Both are supported.
+  1. Both are supported.
 
 v1.16.1 (2020-10-15)
 ====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,13 @@ name = "event-model"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: BSD License",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 description = "Data model used by the bluesky ecosystem."
 dependencies = [
-  "importlib-resources",
   "jsonschema>=4",
   "numpy",
   "typing_extensions",
@@ -23,7 +21,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [
@@ -50,8 +48,8 @@ dev = [
   "numpydoc",
 
   # For schema generation.
-  "pydantic<2.11",
-  "datamodel-code-generator",
+  "pydantic",
+  "datamodel-code-generator>=0.53.0",
 ]
 
 [project.urls]

--- a/src/event_model/__init__.py
+++ b/src/event_model/__init__.py
@@ -1,38 +1,30 @@
 import collections.abc
 import copy
+import importlib.resources as importlib_resources
 import inspect
 import itertools
 import json
 import os
-import sys
 import threading
 import time as ttime
 import uuid
 import warnings
 import weakref
 from collections import defaultdict, deque
+from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
     Any,
-    Callable,
-    Dict,
-    Generator,
-    Iterable,
-    Iterator,
-    List,
-    Optional,
-    Tuple,
-    Type,
-    Union,
+    Literal,
     cast,
     no_type_check,
 )
 
 import jsonschema
 import numpy
-from typing_extensions import Literal
 
+from ._version import __version__
 from .documents.datum import Datum
 from .documents.datum_page import DatumPage
 from .documents.event import Event, PartialEvent
@@ -60,13 +52,6 @@ from .documents.run_start import (
 from .documents.run_stop import RunStop
 from .documents.stream_datum import StreamDatum, StreamRange
 from .documents.stream_resource import StreamResource
-
-if sys.version_info < (3, 9):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
-
-from ._version import __version__
 
 __all__ = [
     # Document types
@@ -147,11 +132,11 @@ class DocumentRouter:
         Expected signature ``f(name, doc)``
     """
 
-    def __init__(self, *, emit: Optional[Callable] = None) -> None:
+    def __init__(self, *, emit: Callable | None = None) -> None:
         # Put in some extra effort to validate `emit` carefully, because if
         # this is used incorrectly the resultant errors can be confusing.
 
-        self._emit_ref: Optional[Callable] = None
+        self._emit_ref: Callable | None = None
 
         if emit is not None:
             if not callable(emit):
@@ -182,7 +167,7 @@ class DocumentRouter:
 
     def __call__(
         self, name: str, doc: dict, validate: bool = False
-    ) -> Tuple[str, dict]:
+    ) -> tuple[str, dict]:
         """
         Process a document.
 
@@ -202,7 +187,7 @@ class DocumentRouter:
         """
         return self._dispatch(name, doc, validate)
 
-    def _dispatch(self, name: str, doc: dict, validate: bool) -> Tuple[str, dict]:
+    def _dispatch(self, name: str, doc: dict, validate: bool) -> tuple[str, dict]:
         """
         Dispatch to the method corresponding to the `name`.
 
@@ -273,16 +258,16 @@ class DocumentRouter:
     # to how Python uses NotImplemented in arithmetic operations, as described
     # in the documentation.
 
-    def start(self, doc: RunStart) -> Optional[RunStart]:
+    def start(self, doc: RunStart) -> RunStart | None:
         return NotImplemented
 
-    def stop(self, doc: RunStop) -> Optional[RunStop]:
+    def stop(self, doc: RunStop) -> RunStop | None:
         return NotImplemented
 
-    def descriptor(self, doc: EventDescriptor) -> Optional[EventDescriptor]:
+    def descriptor(self, doc: EventDescriptor) -> EventDescriptor | None:
         return NotImplemented
 
-    def resource(self, doc: Resource) -> Optional[Resource]:
+    def resource(self, doc: Resource) -> Resource | None:
         return NotImplemented
 
     def event(self, doc: Event) -> Event:
@@ -294,13 +279,13 @@ class DocumentRouter:
     def event_page(self, doc: EventPage) -> EventPage:
         return NotImplemented
 
-    def datum_page(self, doc: DatumPage) -> Optional[DatumPage]:
+    def datum_page(self, doc: DatumPage) -> DatumPage | None:
         return NotImplemented
 
-    def stream_datum(self, doc: StreamDatum) -> Optional[StreamDatum]:
+    def stream_datum(self, doc: StreamDatum) -> StreamDatum | None:
         return NotImplemented
 
-    def stream_resource(self, doc: StreamResource) -> Optional[StreamResource]:
+    def stream_resource(self, doc: StreamResource) -> StreamResource | None:
         return NotImplemented
 
     def bulk_events(self, doc: dict) -> None:
@@ -330,12 +315,12 @@ class SingleRunDocumentRouter(DocumentRouter):
 
     def __init__(self) -> None:
         super().__init__()
-        self._start_doc: Optional[dict] = None
+        self._start_doc: dict | None = None
         self._descriptors: dict = {}
 
     def __call__(
         self, name: str, doc: dict, validate: bool = False
-    ) -> Tuple[str, dict]:
+    ) -> tuple[str, dict]:
         """
         Process a document.
 
@@ -494,13 +479,13 @@ class HandlerRegistryView(collections.abc.Mapping):
 # delayed-computation framework (e.g. dask) in event-model itself.
 
 
-def as_is(handler_class, filler_state) -> Type:
+def as_is(handler_class, filler_state) -> type:
     "A no-op coercion function that returns handler_class unchanged."
     return handler_class
 
 
 @no_type_check
-def force_numpy(handler_class: Type, filler_state) -> Any:
+def force_numpy(handler_class: type, filler_state) -> Any:
     "A coercion that makes handler_class.__call__ return actual numpy.ndarray."
 
     class Subclass(handler_class):
@@ -656,18 +641,18 @@ class Filler(DocumentRouter):
         self,
         handler_registry: dict,
         *,
-        include: Optional[Iterable] = None,
-        exclude: Optional[Iterable] = None,
-        root_map: Optional[dict] = None,
+        include: Iterable | None = None,
+        exclude: Iterable | None = None,
+        root_map: dict | None = None,
         coerce: str = "as_is",
-        handler_cache: Optional[dict] = None,
-        resource_cache: Optional[dict] = None,
-        datum_cache: Optional[dict] = None,
-        descriptor_cache: Optional[dict] = None,
-        stream_resource_cache: Optional[dict] = None,
-        stream_datum_cache: Optional[dict] = None,
-        inplace: Optional[bool] = None,
-        retry_intervals: Optional[List[float]] = None,
+        handler_cache: dict | None = None,
+        resource_cache: dict | None = None,
+        datum_cache: dict | None = None,
+        descriptor_cache: dict | None = None,
+        stream_resource_cache: dict | None = None,
+        stream_datum_cache: dict | None = None,
+        inplace: bool | None = None,
+        retry_intervals: list[float] | None = None,
     ) -> None:
         if retry_intervals is None:
             retry_intervals = [
@@ -821,7 +806,7 @@ class Filler(DocumentRouter):
         self._closed = False
 
     @property
-    def retry_intervals(self) -> List:
+    def retry_intervals(self) -> list:
         return self._retry_intervals
 
     @retry_intervals.setter
@@ -861,18 +846,18 @@ class Filler(DocumentRouter):
 
     def clone(
         self,
-        handler_registry: Optional[dict] = None,
+        handler_registry: dict | None = None,
         *,
-        root_map: Optional[dict] = None,
-        coerce: Optional[str] = None,
-        handler_cache: Optional[dict] = None,
-        resource_cache: Optional[dict] = None,
-        datum_cache: Optional[dict] = None,
-        descriptor_cache: Optional[dict] = None,
-        stream_resource_cache: Optional[dict] = None,
-        stream_datum_cache: Optional[dict] = None,
-        inplace: Optional[bool] = None,
-        retry_intervals: Optional[List] = None,
+        root_map: dict | None = None,
+        coerce: str | None = None,
+        handler_cache: dict | None = None,
+        resource_cache: dict | None = None,
+        datum_cache: dict | None = None,
+        descriptor_cache: dict | None = None,
+        stream_resource_cache: dict | None = None,
+        stream_datum_cache: dict | None = None,
+        inplace: bool | None = None,
+        retry_intervals: list | None = None,
     ) -> "Filler":
         """
         Create a new Filler instance from this one.
@@ -1015,9 +1000,9 @@ class Filler(DocumentRouter):
     def fill_event_page(
         self,
         doc: EventPage,
-        include: Optional[Iterable] = None,
-        exclude: Optional[Iterable] = None,
-        inplace: Optional[bool] = None,
+        include: Iterable | None = None,
+        exclude: Iterable | None = None,
+        inplace: bool | None = None,
     ) -> EventPage:
         filled_events = []
         for event_doc in unpack_event_page(doc):
@@ -1103,9 +1088,9 @@ class Filler(DocumentRouter):
     def fill_event(
         self,
         doc,
-        include: Optional[Iterable] = None,
-        exclude: Optional[Iterable] = None,
-        inplace: Optional[bool] = None,
+        include: Iterable | None = None,
+        exclude: Iterable | None = None,
+        inplace: bool | None = None,
     ) -> Any:
         if inplace is None:
             inplace = self._inplace
@@ -1251,7 +1236,7 @@ class Filler(DocumentRouter):
 
     def __call__(
         self, name: str, doc: dict, validate: bool = False
-    ) -> Tuple[str, dict]:
+    ) -> tuple[str, dict]:
         if self._closed:
             raise EventModelRuntimeError(
                 "This Filler has been closed and is no longer usable."
@@ -1267,7 +1252,7 @@ def _attempt_with_retries(
     args,
     kwargs,
     intervals: Iterable,
-    error_to_catch: Type[OSError],
+    error_to_catch: type[OSError],
     error_to_raise: EventModelError,
 ) -> Any:
     """
@@ -1318,8 +1303,8 @@ class NoFiller(Filler):
     def fill_event_page(
         self,
         doc: EventPage,
-        include: Optional[Iterable] = None,
-        exclude: Optional[Iterable] = None,
+        include: Iterable | None = None,
+        exclude: Iterable | None = None,
         *kwargs,
     ) -> EventPage:
         filled_events = []
@@ -1335,9 +1320,9 @@ class NoFiller(Filler):
     def fill_event(
         self,
         doc: Event,
-        include: Optional[Iterable] = None,
-        exclude: Optional[Iterable] = None,
-        inplace: Optional[bool] = None,
+        include: Iterable | None = None,
+        exclude: Iterable | None = None,
+        inplace: bool | None = None,
     ) -> Event:
         descriptor = self._descriptor_cache[doc["descriptor"]]
         from_datakeys = False
@@ -1496,10 +1481,10 @@ class RunRouter(DocumentRouter):
     def __init__(
         self,
         factories,
-        handler_registry: Optional[dict] = None,
+        handler_registry: dict | None = None,
         *,
-        root_map: Optional[dict] = None,
-        filler_class: Type[Filler] = Filler,
+        root_map: dict | None = None,
+        filler_class: type[Filler] = Filler,
         fill_or_fail: bool = False,
     ) -> None:
         self.factories = factories
@@ -1868,7 +1853,7 @@ class ComposeDatum:
     resource: Resource
     counter: Iterator
 
-    def __call__(self, datum_kwargs: Dict[str, Any], validate: bool = True) -> Datum:
+    def __call__(self, datum_kwargs: dict[str, Any], validate: bool = True) -> Datum:
         resource_uid = self.resource["uid"]
         doc = Datum(
             resource=resource_uid,
@@ -1884,7 +1869,7 @@ def compose_datum(
     *,
     resource: Resource,
     counter: Iterator,
-    datum_kwargs: Dict[str, Any],
+    datum_kwargs: dict[str, Any],
     validate: bool = True,
 ) -> Datum:
     """
@@ -1916,7 +1901,7 @@ def compose_datum_page(
     *,
     resource: Resource,
     counter: Iterator,
-    datum_kwargs: Dict[str, List[Any]],
+    datum_kwargs: dict[str, list[Any]],
     validate: bool = True,
 ) -> DatumPage:
     """
@@ -1942,7 +1927,7 @@ class ComposeResourceBundle:
         )
 
 
-PATH_SEMANTICS: Dict[str, Literal["posix", "windows"]] = {
+PATH_SEMANTICS: dict[str, Literal["posix", "windows"]] = {
     "posix": "posix",
     "nt": "windows",
 }
@@ -1951,16 +1936,16 @@ default_path_semantics: Literal["posix", "windows"] = PATH_SEMANTICS[os.name]
 
 @dataclass
 class ComposeResource:
-    start: Optional[RunStart]
+    start: RunStart | None
 
     def __call__(
         self,
         spec: str,
         root: str,
         resource_path: str,
-        resource_kwargs: Dict[str, Any],
+        resource_kwargs: dict[str, Any],
         path_semantics: Literal["posix", "windows"] = default_path_semantics,
-        uid: Optional[str] = None,
+        uid: str | None = None,
         validate: bool = True,
     ) -> ComposeResourceBundle:
         if uid is None:
@@ -1994,10 +1979,10 @@ def compose_resource(
     spec: str,
     root: str,
     resource_path: str,
-    resource_kwargs: Dict[str, Any],
+    resource_kwargs: dict[str, Any],
     path_semantics: Literal["posix", "windows"] = default_path_semantics,
-    start: Optional[RunStart] = None,
-    uid: Optional[str] = None,
+    start: RunStart | None = None,
+    uid: str | None = None,
     validate: bool = True,
 ) -> ComposeResourceBundle:
     """
@@ -2022,8 +2007,8 @@ class ComposeStreamDatum:
     def __call__(
         self,
         indices: StreamRange,
-        seq_nums: Optional[StreamRange] = None,
-        descriptor: Optional[EventDescriptor] = None,
+        seq_nums: StreamRange | None = None,
+        descriptor: EventDescriptor | None = None,
         validate: bool = True,
     ) -> StreamDatum:
         resource_uid = self.stream_resource["uid"]
@@ -2087,15 +2072,15 @@ class ComposeStreamResourceBundle:
 
 @dataclass
 class ComposeStreamResource:
-    start: Optional[RunStart] = None
+    start: RunStart | None = None
 
     def __call__(
         self,
         mimetype: str,
         uri: str,
         data_key: str,
-        parameters: Dict[str, Any],
-        uid: Optional[str] = None,
+        parameters: dict[str, Any],
+        uid: str | None = None,
         validate: bool = True,
     ) -> ComposeStreamResourceBundle:
         if uid is None:
@@ -2129,9 +2114,9 @@ def compose_stream_resource(
     mimetype: str,
     uri: str,
     data_key: str,
-    parameters: Dict[str, Any],
-    start: Optional[RunStart] = None,
-    uid: Optional[str] = None,
+    parameters: dict[str, Any],
+    start: RunStart | None = None,
+    uid: str | None = None,
     validate: bool = True,
 ) -> ComposeStreamResourceBundle:
     """
@@ -2150,15 +2135,15 @@ def compose_stream_resource(
 @dataclass
 class ComposeStop:
     start: RunStart
-    event_counters: Dict[str, int]
-    poison_pill: List
+    event_counters: dict[str, int]
+    poison_pill: list
 
     def __call__(
         self,
         exit_status: Literal["success", "abort", "fail"] = "success",
         reason: str = "",
-        uid: Optional[str] = None,
-        time: Optional[float] = None,
+        uid: str | None = None,
+        time: float | None = None,
         validate: bool = True,
     ) -> RunStop:
         if self.poison_pill:
@@ -2188,12 +2173,12 @@ class ComposeStop:
 def compose_stop(
     *,
     start: RunStart,
-    event_counters: Dict[str, int],
-    poison_pill: List,
+    event_counters: dict[str, int],
+    poison_pill: list,
     exit_status: Literal["success", "abort", "fail"] = "success",
     reason: str = "",
-    uid: Optional[str] = None,
-    time: Optional[float] = None,
+    uid: str | None = None,
+    time: float | None = None,
     validate: bool = True,
 ) -> RunStop:
     """
@@ -2206,7 +2191,7 @@ def compose_stop(
     )(exit_status=exit_status, reason=reason, uid=uid, time=time, validate=validate)
 
 
-def length_of_value(dictionary: Dict[str, List], error_msg: str) -> Optional[int]:
+def length_of_value(dictionary: dict[str, list], error_msg: str) -> int | None:
     length = None
     for _, v in dictionary.items():
         v_len = len(v)
@@ -2220,16 +2205,16 @@ def length_of_value(dictionary: Dict[str, List], error_msg: str) -> Optional[int
 @dataclass
 class ComposeEventPage:
     descriptor: EventDescriptor
-    event_counters: Dict[str, int]
+    event_counters: dict[str, int]
 
     def __call__(
         self,
-        data: Dict[str, List],
-        timestamps: Dict[str, Any],
-        seq_num: Optional[List[int]] = None,
-        filled: Optional[Dict[str, List[Union[bool, str]]]] = None,
-        uid: Optional[List] = None,
-        time: Optional[List] = None,
+        data: dict[str, list],
+        timestamps: dict[str, Any],
+        seq_num: list[int] | None = None,
+        filled: dict[str, list[bool | str]] | None = None,
+        uid: list | None = None,
+        time: list | None = None,
         validate: bool = True,
     ) -> EventPage:
         timestamps_length = length_of_value(
@@ -2305,13 +2290,13 @@ class ComposeEventPage:
 def compose_event_page(
     *,
     descriptor: EventDescriptor,
-    event_counters: Dict[str, int],
-    data: Dict[str, List],
-    timestamps: Dict[str, Any],
-    seq_num: List[int],
-    filled: Optional[Dict[str, List[Union[bool, str]]]] = None,
-    uid: Optional[List] = None,
-    time: Optional[List] = None,
+    event_counters: dict[str, int],
+    data: dict[str, list],
+    timestamps: dict[str, Any],
+    seq_num: list[int],
+    filled: dict[str, list[bool | str]] | None = None,
+    uid: list | None = None,
+    time: list | None = None,
     validate: bool = True,
 ) -> EventPage:
     """
@@ -2342,16 +2327,16 @@ def keys_without_stream_keys(dictionary, descriptor_data_keys):
 @dataclass
 class ComposeEvent:
     descriptor: EventDescriptor
-    event_counters: Dict[str, int]
+    event_counters: dict[str, int]
 
     def __call__(
         self,
         data: dict,
         timestamps: dict,
-        seq_num: Optional[int] = None,
-        filled: Optional[Dict[str, Union[bool, str]]] = None,
-        uid: Optional[str] = None,
-        time: Optional[float] = None,
+        seq_num: int | None = None,
+        filled: dict[str, bool | str] | None = None,
+        uid: str | None = None,
+        time: float | None = None,
         validate: bool = True,
     ) -> Event:
         if seq_num is None:
@@ -2408,13 +2393,13 @@ class ComposeEvent:
 def compose_event(
     *,
     descriptor: EventDescriptor,
-    event_counters: Dict[str, int],
-    data: Dict[str, Any],
-    timestamps: Dict[str, Any],
+    event_counters: dict[str, int],
+    data: dict[str, Any],
+    timestamps: dict[str, Any],
     seq_num: int,
-    filled: Optional[Dict[str, Union[bool, str]]] = None,
-    uid: Optional[str] = None,
-    time: Optional[float] = None,
+    filled: dict[str, bool | str] | None = None,
+    uid: str | None = None,
+    time: float | None = None,
     validate: bool = True,
 ) -> Event:
     """
@@ -2451,7 +2436,7 @@ class ComposeDescriptorBundle:
 class ComposeDescriptor:
     start: RunStart
     streams: dict
-    event_counters: Dict[str, int]
+    event_counters: dict[str, int]
 
     def __call__(
         self,
@@ -2513,15 +2498,15 @@ class ComposeDescriptor:
 def compose_descriptor(
     *,
     start: RunStart,
-    streams: Dict[str, Iterable],
-    event_counters: Dict[str, int],
+    streams: dict[str, Iterable],
+    event_counters: dict[str, int],
     name: str,
-    data_keys: Dict[str, DataKey],
-    uid: Optional[str] = None,
-    time: Optional[float] = None,
-    object_keys: Optional[Dict[str, Any]] = None,
-    configuration: Optional[Dict[str, Configuration]] = None,
-    hints: Optional[PerObjectHint] = None,
+    data_keys: dict[str, DataKey],
+    uid: str | None = None,
+    time: float | None = None,
+    object_keys: dict[str, Any] | None = None,
+    configuration: dict[str, Configuration] | None = None,
+    hints: PerObjectHint | None = None,
     validate: bool = True,
 ) -> ComposeDescriptorBundle:
     """
@@ -2552,7 +2537,7 @@ class ComposeRunBundle:
     compose_descriptor: ComposeDescriptor
     compose_resource: ComposeResource
     compose_stop: ComposeStop
-    compose_stream_resource: Optional[ComposeStreamResource] = None
+    compose_stream_resource: ComposeStreamResource | None = None
 
     # iter for backwards compatibility
     def __iter__(self) -> Iterator:
@@ -2568,11 +2553,11 @@ class ComposeRunBundle:
 
 def compose_run(
     *,
-    uid: Optional[str] = None,
-    time: Optional[float] = None,
-    metadata: Optional[Dict] = None,
+    uid: str | None = None,
+    time: float | None = None,
+    metadata: dict | None = None,
     validate: bool = True,
-    event_counters: Optional[Dict[str, int]] = None,
+    event_counters: dict[str, int] | None = None,
 ) -> ComposeRunBundle:
     """
     Compose a RunStart document and factory functions for related documents.
@@ -2607,7 +2592,7 @@ def compose_run(
 
     # Define some mutable state to be shared internally by the closures composed
     # below.
-    streams: Dict[str, Iterable] = {}
+    streams: dict[str, Iterable] = {}
     if event_counters is None:
         event_counters = {}
     poison_pill: list = []
@@ -3043,8 +3028,8 @@ def _transpose_dict_of_lists(dict_of_lists: dict) -> list:
     "Transform dict-of-lists (i.e. DataFrame-like) into list-of-dicts."
     list_of_dicts = []
     keys = list(dict_of_lists)
-    for row in zip(*(dict_of_lists[k] for k in keys)):
-        list_of_dicts.append(dict(zip(keys, row)))
+    for row in zip(*(dict_of_lists[k] for k in keys), strict=False):
+        list_of_dicts.append(dict(zip(keys, row, strict=False)))
     return list_of_dicts
 
 
@@ -3119,7 +3104,7 @@ class NumpyEncoder(json.JSONEncoder):
                 obj = numpy.asarray(obj)
         except ImportError:
             pass
-        if isinstance(obj, (numpy.generic, numpy.ndarray)):
+        if isinstance(obj, numpy.generic | numpy.ndarray):
             if numpy.isscalar(obj):
                 return obj.item()
             return obj.tolist()

--- a/src/event_model/basemodels/__init__.py
+++ b/src/event_model/basemodels/__init__.py
@@ -1,5 +1,3 @@
-from typing import Tuple, Type, Union
-
 from event_model.basemodels.datum import Datum
 from event_model.basemodels.datum_page import DatumPage
 from event_model.basemodels.event import Event
@@ -16,33 +14,33 @@ from event_model.basemodels.run_stop import RunStop
 from event_model.basemodels.stream_datum import StreamDatum
 from event_model.basemodels.stream_resource import StreamResource
 
-DocumentType = Union[
-    Type[Datum],
-    Type[DatumPage],
-    Type[Event],
-    Type[EventDescriptor],
-    Type[EventPage],
-    Type[Resource],
-    Type[RunStart],
-    Type[RunStop],
-    Type[StreamDatum],
-    Type[StreamResource],
-]
+DocumentType = (
+    type[Datum]
+    | type[DatumPage]
+    | type[Event]
+    | type[EventDescriptor]
+    | type[EventPage]
+    | type[Resource]
+    | type[RunStart]
+    | type[RunStop]
+    | type[StreamDatum]
+    | type[StreamResource]
+)
 
-Document = Union[
-    Datum,
-    DatumPage,
-    Event,
-    EventDescriptor,
-    EventPage,
-    Resource,
-    RunStart,
-    RunStop,
-    StreamDatum,
-    StreamResource,
-]
+Document = (
+    Datum
+    | DatumPage
+    | Event
+    | EventDescriptor
+    | EventPage
+    | Resource
+    | RunStart
+    | RunStop
+    | StreamDatum
+    | StreamResource
+)
 
-ALL_BASEMODELS: Tuple[DocumentType, ...] = (
+ALL_BASEMODELS: tuple[DocumentType, ...] = (
     Datum,
     DatumPage,
     Event,

--- a/src/event_model/basemodels/datum.py
+++ b/src/event_model/basemodels/datum.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict
+from typing import Annotated, Any
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
 )
-from typing_extensions import Annotated
 
 
 class Datum(BaseModel):
@@ -21,7 +20,7 @@ class Datum(BaseModel):
         ),
     ]
     datum_kwargs: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             description="Arguments to pass to the Handler to "
             "retrieve one quanta of data",

--- a/src/event_model/basemodels/datum_page.py
+++ b/src/event_model/basemodels/datum_page.py
@@ -1,11 +1,10 @@
-from typing import Any, Dict, List
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
-from typing_extensions import Annotated
 
 
 class DataFrameForDatumPage(RootModel):
-    root: List[str] = Field(alias="Dataframe")
+    root: list[str] = Field(alias="Dataframe")
 
 
 class DatumPage(BaseModel):
@@ -21,7 +20,7 @@ class DatumPage(BaseModel):
         ),
     ]
     datum_kwargs: Annotated[
-        Dict[str, List[Any]],
+        dict[str, list[Any]],
         Field(
             description="Array of arguments to pass to the Handler to "
             "retrieve one quanta of data"

--- a/src/event_model/basemodels/event.py
+++ b/src/event_model/basemodels/event.py
@@ -1,15 +1,14 @@
-from typing import Any, Dict, Union
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Annotated
 
 
 class PartialEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    data: Annotated[Dict[str, Any], Field(description="The actual measurement data")]
+    data: Annotated[dict[str, Any], Field(description="The actual measurement data")]
     filled: Annotated[
-        Dict[str, Union[bool, str]],
+        dict[str, bool | str],
         Field(
             default_factory=dict,
             description="Mapping each of the keys of externally-stored data to the "
@@ -25,7 +24,7 @@ class PartialEvent(BaseModel):
         ),
     ]
     timestamps: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(description="The timestamps of the individual measurement data"),
     ]
 

--- a/src/event_model/basemodels/event_descriptor.py
+++ b/src/event_model/basemodels/event_descriptor.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -10,7 +10,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic.config import JsonDict
-from typing_extensions import Annotated, Literal
 
 
 class Dtype(RootModel):
@@ -40,8 +39,8 @@ class DataType(RootModel):
 class LimitsRange(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    low: Optional[float]
-    high: Optional[float]
+    low: float | None
+    high: float | None
 
 
 class RdsRange(BaseModel):
@@ -80,24 +79,20 @@ class Limits(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     control: Annotated[
-        Optional[LimitsRange], Field(default=None, description="Control limits.")
+        LimitsRange | None, Field(default=None, description="Control limits.")
     ]
     display: Annotated[
-        Optional[LimitsRange], Field(default=None, description="Display limits.")
+        LimitsRange | None, Field(default=None, description="Display limits.")
     ]
     warning: Annotated[
-        Optional[LimitsRange], Field(default=None, description="Warning limits.")
+        LimitsRange | None, Field(default=None, description="Warning limits.")
     ]
     alarm: Annotated[
-        Optional[LimitsRange], Field(default=None, description="Alarm limits.")
+        LimitsRange | None, Field(default=None, description="Alarm limits.")
     ]
 
-    hysteresis: Annotated[
-        Optional[float], Field(default=None, description="Hysteresis.")
-    ]
-    rds: Annotated[
-        Optional[RdsRange], Field(default=None, description="RDS parameters.")
-    ]
+    hysteresis: Annotated[float | None, Field(default=None, description="Hysteresis.")]
+    rds: Annotated[RdsRange | None, Field(default=None, description="RDS parameters.")]
 
 
 _ConstrainedDtype = Annotated[
@@ -108,7 +103,7 @@ _ConstrainedDtype = Annotated[
     ),
 ]
 
-_ConstrainedDtypeNpStructure = List[Tuple[str, _ConstrainedDtype]]
+_ConstrainedDtypeNpStructure = list[tuple[str, _ConstrainedDtype]]
 
 
 class DataKey(BaseModel):
@@ -131,11 +126,11 @@ class DataKey(BaseModel):
         ),
     ]
     choices: Annotated[
-        List[str],
+        list[str],
         Field(default=[], description="Choices of enum value."),
     ]
     dims: Annotated[
-        List[str],
+        list[str],
         Field(
             default=[],
             description="The names for dimensions of the data. Null or empty list "
@@ -151,7 +146,7 @@ class DataKey(BaseModel):
         ),
     ]
     dtype_numpy: Annotated[
-        Union[_ConstrainedDtype, _ConstrainedDtypeNpStructure],
+        _ConstrainedDtype | _ConstrainedDtypeNpStructure,
         Field(
             default="",
             validate_default=False,
@@ -178,7 +173,7 @@ class DataKey(BaseModel):
         ),
     ]
     precision: Annotated[
-        Optional[int],
+        int | None,
         Field(
             default=None,
             description="Number of digits after decimal place if "
@@ -186,7 +181,7 @@ class DataKey(BaseModel):
         ),
     ]
     shape: Annotated[
-        List[Optional[int]],
+        list[int | None],
         Field(
             description="The shape of the data.  Empty list indicates scalar data. "
             "None indicates a dimension with unknown or variable length."
@@ -196,7 +191,7 @@ class DataKey(BaseModel):
         str, Field(description="The source (ex piece of hardware) of the data.")
     ]
     units: Annotated[
-        Optional[str],
+        str | None,
         Field(default=None, description="Engineering units of the value"),
     ]
 
@@ -207,7 +202,7 @@ class PerObjectHint(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     fields: Annotated[
-        List[str],
+        list[str],
         Field(description="The 'interesting' data keys for this device."),
     ] = []
     NX_class: Annotated[
@@ -223,11 +218,11 @@ class PerObjectHint(BaseModel):
 class Configuration(BaseModel):
     model_config = ConfigDict(extra="allow")
     data: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(default={}, description="The actual measurement data"),
     ]
     data_keys: Annotated[
-        Dict[str, DataKey],
+        dict[str, DataKey],
         Field(
             default={},
             description="This describes the data stored alongside it in this "
@@ -235,7 +230,7 @@ class Configuration(BaseModel):
         ),
     ]
     timestamps: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             default={},
             description="The timestamps of the individual measurement data",
@@ -266,7 +261,7 @@ class EventDescriptor(BaseModel):
     )
 
     configuration: Annotated[
-        Dict[str, Configuration],
+        dict[str, Configuration],
         Field(
             default={},
             description="Readings of configurational fields necessary for "
@@ -274,7 +269,7 @@ class EventDescriptor(BaseModel):
         ),
     ]
     data_keys: Annotated[
-        Dict[str, DataKey],
+        dict[str, DataKey],
         Field(
             description="This describes the data in the Event Documents.",
             title="data_keys",
@@ -290,7 +285,7 @@ class EventDescriptor(BaseModel):
         ),
     ]
     object_keys: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             default={},
             description="Maps a Device/Signal name to the names of the entries "

--- a/src/event_model/basemodels/event_page.py
+++ b/src/event_model/basemodels/event_page.py
@@ -1,14 +1,13 @@
-from typing import Dict, List, Union
+from typing import Annotated
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
 )
-from typing_extensions import Annotated
 
-DataFrameForFilled = Dict[str, List[Union[bool, str]]]
-DataFrameForEventPage = Dict[str, List]
+DataFrameForFilled = dict[str, list[bool | str]]
+DataFrameForEventPage = dict[str, list]
 
 
 class PartialEventPage(BaseModel):
@@ -33,7 +32,7 @@ class PartialEventPage(BaseModel):
         Field(description="The timestamps of the individual measurement data"),
     ]
     time: Annotated[
-        List[float],
+        list[float],
         Field(
             description="Array of Event times. This maybe different than the "
             "timestamps on each of the data entries"
@@ -55,13 +54,13 @@ class EventPage(PartialEventPage):
     ]
 
     seq_num: Annotated[
-        List[int],
+        list[int],
         Field(
             description="Array of sequence numbers to identify the location of each "
             "Event in the Event stream",
         ),
     ]
     uid: Annotated[
-        List[str],
+        list[str],
         Field(description="Array of globally unique identifiers for each Event"),
     ]

--- a/src/event_model/basemodels/resource.py
+++ b/src/event_model/basemodels/resource.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Annotated, Literal
 
 
 class PartialResource(BaseModel):
@@ -18,7 +17,7 @@ class PartialResource(BaseModel):
         str, Field(description="Filepath or URI for locating this resource")
     ]
     resource_kwargs: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             description="Additional argument to pass to the Handler to read a Resource"
         ),

--- a/src/event_model/basemodels/run_start.py
+++ b/src/event_model/basemodels/run_start.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -10,7 +10,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic.config import JsonDict
-from typing_extensions import Annotated, Literal
 
 NO_DOTS_PATTERN = r"^([^./]+)$"
 
@@ -38,7 +37,7 @@ class Hints(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     dimensions: Annotated[
-        List[List[Union[List[str], str]]],
+        list[list[list[str] | str]],
         Field(
             description="The independent axes of the experiment. Ordered slow to fast",
             default=[],
@@ -50,12 +49,12 @@ class Hints(BaseModel):
 class Calculation(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    args: Annotated[List, Field(default=[])]
+    args: Annotated[list, Field(default=[])]
     callable: Annotated[
         str, Field(description="callable function to perform calculation")
     ]
     kwargs: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(description="kwargs for calcalation callable", default={}),
     ]
 
@@ -162,18 +161,16 @@ class Projections(BaseModel):
     """Describe how to interperet this run as the given projection"""
 
     configuration: Annotated[
-        Dict[str, Any], Field(description="Static information about projection")
+        dict[str, Any], Field(description="Static information about projection")
     ]
     name: Annotated[str, Field(description="The name of the projection", default="")]
     projection: Annotated[
-        Dict[
+        dict[
             Any,
-            Union[
-                ConfigurationProjection,
-                LinkedEventProjection,
-                CalculatedEventProjection,
-                StaticProjection,
-            ],
+            ConfigurationProjection
+            | LinkedEventProjection
+            | CalculatedEventProjection
+            | StaticProjection,
         ],
         Field(description=""),
     ]
@@ -195,7 +192,7 @@ class RunStart(BaseModel):
     model_config = ConfigDict(extra="allow", json_schema_extra=RUN_START_EXTRA_SCHEMA)
 
     data_groups: Annotated[
-        List[str],
+        list[str],
         Field(
             description="An optional list of data access groups that have meaning "
             "to some external system. Examples might include facility, beamline, "
@@ -233,9 +230,9 @@ class RunStart(BaseModel):
         str,
         Field(description="Name of project that this run is part of", default=""),
     ]
-    projections: Annotated[List[Projections], Field(description="", default=[])]
+    projections: Annotated[list[Projections], Field(description="", default=[])]
     sample: Annotated[
-        Union[Dict[str, Any], str],
+        dict[str, Any] | str,
         Field(
             description="Information about the sample, may be a UID to "
             "another collection",

--- a/src/event_model/basemodels/run_stop.py
+++ b/src/event_model/basemodels/run_stop.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict
+from typing import Annotated, Any, Literal
 
 from pydantic import (
     BaseModel,
@@ -10,7 +10,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic.config import JsonDict
-from typing_extensions import Annotated, Literal
 
 NO_DOTS_PATTERN = r"^([^./]+)$"
 
@@ -58,7 +57,7 @@ class RunStop(BaseModel):
         Field(description="State of the run when it ended"),
     ]
     num_events: Annotated[
-        Dict[str, int],
+        dict[str, int],
         Field(
             description="Number of Events per named stream",
             default={},

--- a/src/event_model/basemodels/stream_datum.py
+++ b/src/event_model/basemodels/stream_datum.py
@@ -1,7 +1,6 @@
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
-from typing_extensions import Annotated
 
 
 class DataType(RootModel):

--- a/src/event_model/basemodels/stream_resource.py
+++ b/src/event_model/basemodels/stream_resource.py
@@ -1,7 +1,6 @@
-from typing import Any, Dict
+from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import Annotated
 
 
 class StreamResource(BaseModel):
@@ -22,7 +21,7 @@ class StreamResource(BaseModel):
         ),
     ]
     parameters: Annotated[
-        Dict[str, Any],
+        dict[str, Any],
         Field(
             description="Additional keyword arguments to pass to the Handler to read a "
             "Stream Resource",

--- a/src/event_model/documents/__init__.py
+++ b/src/event_model/documents/__init__.py
@@ -1,7 +1,5 @@
 # generated in `event_model/generate`
 
-from typing import Tuple, Type, Union
-
 from .datum import *  # noqa: F403
 from .datum_page import *  # noqa: F403
 from .event import *  # noqa: F403
@@ -13,33 +11,33 @@ from .run_stop import *  # noqa: F403
 from .stream_datum import *  # noqa: F403
 from .stream_resource import *  # noqa: F403
 
-DocumentType = Union[
-    Type[Datum],  # noqa: F405,
-    Type[DatumPage],  # noqa: F405,
-    Type[Event],  # noqa: F405,
-    Type[EventDescriptor],  # noqa: F405,
-    Type[EventPage],  # noqa: F405,
-    Type[Resource],  # noqa: F405,
-    Type[RunStart],  # noqa: F405,
-    Type[RunStop],  # noqa: F405,
-    Type[StreamDatum],  # noqa: F405,
-    Type[StreamResource],  # noqa: F405,
-]
+DocumentType = (
+    type[Datum]  # noqa: F405
+    | type[DatumPage]  # noqa: F405
+    | type[Event]  # noqa: F405
+    | type[EventDescriptor]  # noqa: F405
+    | type[EventPage]  # noqa: F405
+    | type[Resource]  # noqa: F405
+    | type[RunStart]  # noqa: F405
+    | type[RunStop]  # noqa: F405
+    | type[StreamDatum]  # noqa: F405
+    | type[StreamResource]  # noqa: F405
+)
 
-Document = Union[
-    Datum,  # noqa: F405
-    DatumPage,  # noqa: F405
-    Event,  # noqa: F405
-    EventDescriptor,  # noqa: F405
-    EventPage,  # noqa: F405
-    Resource,  # noqa: F405
-    RunStart,  # noqa: F405
-    RunStop,  # noqa: F405
-    StreamDatum,  # noqa: F405
-    StreamResource,  # noqa: F405
-]
+Document = (
+    Datum  # noqa: F405
+    | DatumPage  # noqa: F405
+    | Event  # noqa: F405
+    | EventDescriptor  # noqa: F405
+    | EventPage  # noqa: F405
+    | Resource  # noqa: F405
+    | RunStart  # noqa: F405
+    | RunStop  # noqa: F405
+    | StreamDatum  # noqa: F405
+    | StreamResource  # noqa: F405
+)
 
-ALL_DOCUMENTS: Tuple[DocumentType, ...] = (
+ALL_DOCUMENTS: tuple[DocumentType, ...] = (
     Datum,  # noqa: F405
     DatumPage,  # noqa: F405
     Event,  # noqa: F405

--- a/src/event_model/documents/datum.py
+++ b/src/event_model/documents/datum.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, TypedDict
+from typing import Any, TypedDict
 
 
 class Datum(TypedDict):
@@ -16,7 +16,7 @@ class Datum(TypedDict):
     """
     Globally unique identifier for this Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'
     """
-    datum_kwargs: Dict[str, Any]
+    datum_kwargs: dict[str, Any]
     """
     Arguments to pass to the Handler to retrieve one quanta of data
     """

--- a/src/event_model/documents/datum_page.py
+++ b/src/event_model/documents/datum_page.py
@@ -4,9 +4,9 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, TypedDict
+from typing import Any, TypeAlias, TypedDict
 
-DataFrameForDatumPage = List[str]
+DataFrameForDatumPage: TypeAlias = list[str]
 
 
 class DatumPage(TypedDict):
@@ -18,7 +18,7 @@ class DatumPage(TypedDict):
     """
     Array unique identifiers for each Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'
     """
-    datum_kwargs: Dict[str, List]
+    datum_kwargs: dict[str, list[Any]]
     """
     Array of arguments to pass to the Handler to retrieve one quanta of data
     """

--- a/src/event_model/documents/event.py
+++ b/src/event_model/documents/event.py
@@ -4,17 +4,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, TypedDict, Union
+from typing import Any, TypedDict
 
 from typing_extensions import NotRequired
 
 
 class PartialEvent(TypedDict):
-    data: Dict[str, Any]
+    data: dict[str, Any]
     """
     The actual measurement data
     """
-    filled: NotRequired[Dict[str, Union[bool, str]]]
+    filled: NotRequired[dict[str, bool | str]]
     """
     Mapping each of the keys of externally-stored data to the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)
     """
@@ -22,7 +22,7 @@ class PartialEvent(TypedDict):
     """
     The event time. This maybe different than the timestamps on each of the data entries.
     """
-    timestamps: Dict[str, Any]
+    timestamps: dict[str, Any]
     """
     The timestamps of the individual measurement data
     """

--- a/src/event_model/documents/event_descriptor.py
+++ b/src/event_model/documents/event_descriptor.py
@@ -4,25 +4,34 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal, Optional, TypedDict, Union
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from typing_extensions import NotRequired
 
-DtypeNumpy = str
+DtypeNumpy: TypeAlias = str
+"""
+A numpy dtype e.g `<U9`, `<f16`
+"""
 
 
-DtypeNumpyItem = List
+DtypeNumpyItemItem: TypeAlias = str
+"""
+A numpy dtype e.g `<U9`, `<f16`
+"""
 
 
-DataType = Any
+DtypeNumpyItem: TypeAlias = tuple[str, DtypeNumpyItemItem]
 
 
-Dtype = Literal["string", "number", "array", "boolean", "integer"]
+DataType: TypeAlias = dict[str, "DataType"]
+
+
+Dtype: TypeAlias = Literal["string", "number", "array", "boolean", "integer"]
 
 
 class LimitsRange(TypedDict):
-    high: Optional[float]
-    low: Optional[float]
+    high: float | None
+    low: float | None
 
 
 class PerObjectHint(TypedDict):
@@ -34,7 +43,7 @@ class PerObjectHint(TypedDict):
     """
     The NeXus class definition for this device.
     """
-    fields: NotRequired[List[str]]
+    fields: NotRequired[list[str]]
     """
     The 'interesting' data keys for this device.
     """
@@ -64,27 +73,27 @@ class Limits(TypedDict):
     https://docs.epics-controls.org/en/latest/getting-started/EPICS_Intro.html#channel-access
     """
 
-    alarm: NotRequired[Optional[LimitsRange]]
+    alarm: NotRequired[LimitsRange | None]
     """
     Alarm limits.
     """
-    control: NotRequired[Optional[LimitsRange]]
+    control: NotRequired[LimitsRange | None]
     """
     Control limits.
     """
-    display: NotRequired[Optional[LimitsRange]]
+    display: NotRequired[LimitsRange | None]
     """
     Display limits.
     """
-    hysteresis: NotRequired[Optional[float]]
+    hysteresis: NotRequired[float | None]
     """
     Hysteresis.
     """
-    rds: NotRequired[Optional[RdsRange]]
+    rds: NotRequired[RdsRange | None]
     """
     RDS parameters.
     """
-    warning: NotRequired[Optional[LimitsRange]]
+    warning: NotRequired[LimitsRange | None]
     """
     Warning limits.
     """
@@ -95,11 +104,11 @@ class DataKey(TypedDict):
     Describes the objects in the data property of Event documents
     """
 
-    choices: NotRequired[List[str]]
+    choices: NotRequired[list[str]]
     """
     Choices of enum value.
     """
-    dims: NotRequired[List[str]]
+    dims: NotRequired[list[str]]
     """
     The names for dimensions of the data. Null or empty list if scalar data
     """
@@ -107,7 +116,7 @@ class DataKey(TypedDict):
     """
     The type of the data in the event, given as a broad JSON schema type.
     """
-    dtype_numpy: NotRequired[Union[DtypeNumpy, List[DtypeNumpyItem]]]
+    dtype_numpy: NotRequired[DtypeNumpy | list[DtypeNumpyItem]]
     """
     The type of the data in the event, given as a numpy dtype string (or, for structured dtypes, array).
     """
@@ -123,11 +132,11 @@ class DataKey(TypedDict):
     """
     The name of the object this key was pulled from.
     """
-    precision: NotRequired[Optional[int]]
+    precision: NotRequired[int | None]
     """
     Number of digits after decimal place if a floating point number
     """
-    shape: List[Optional[int]]
+    shape: list[int | None]
     """
     The shape of the data.  Empty list indicates scalar data. None indicates a dimension with unknown or variable length.
     """
@@ -135,22 +144,22 @@ class DataKey(TypedDict):
     """
     The source (ex piece of hardware) of the data.
     """
-    units: NotRequired[Optional[str]]
+    units: NotRequired[str | None]
     """
     Engineering units of the value
     """
 
 
 class Configuration(TypedDict):
-    data: NotRequired[Dict[str, Any]]
+    data: NotRequired[dict[str, Any]]
     """
     The actual measurement data
     """
-    data_keys: NotRequired[Dict[str, DataKey]]
+    data_keys: NotRequired[dict[str, DataKey]]
     """
     This describes the data stored alongside it in this configuration object.
     """
-    timestamps: NotRequired[Dict[str, Any]]
+    timestamps: NotRequired[dict[str, Any]]
     """
     The timestamps of the individual measurement data
     """
@@ -162,11 +171,11 @@ class EventDescriptor(TypedDict):
     documents
     """
 
-    configuration: NotRequired[Dict[str, Configuration]]
+    configuration: NotRequired[dict[str, Configuration]]
     """
     Readings of configurational fields necessary for interpreting data in the Events.
     """
-    data_keys: Dict[str, DataKey]
+    data_keys: dict[str, DataKey]
     """
     This describes the data in the Event Documents.
     """
@@ -175,7 +184,7 @@ class EventDescriptor(TypedDict):
     """
     A human-friendly name for this data stream, such as 'primary' or 'baseline'.
     """
-    object_keys: NotRequired[Dict[str, Any]]
+    object_keys: NotRequired[dict[str, Any]]
     """
     Maps a Device/Signal name to the names of the entries it produces in data_keys.
     """

--- a/src/event_model/documents/event_page.py
+++ b/src/event_model/documents/event_page.py
@@ -4,25 +4,25 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, TypedDict, Union
+from typing import Any, TypedDict
 
 from typing_extensions import NotRequired
 
 
 class PartialEventPage(TypedDict):
-    data: Dict[str, List]
+    data: dict[str, list[Any]]
     """
     The actual measurement data
     """
-    filled: NotRequired[Dict[str, List[Union[bool, str]]]]
+    filled: NotRequired[dict[str, list[bool | str]]]
     """
     Mapping each of the keys of externally-stored data to an array containing the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)
     """
-    time: List[float]
+    time: list[float]
     """
     Array of Event times. This maybe different than the timestamps on each of the data entries
     """
-    timestamps: Dict[str, List]
+    timestamps: dict[str, list[Any]]
     """
     The timestamps of the individual measurement data
     """
@@ -37,11 +37,11 @@ class EventPage(PartialEventPage):
     """
     The UID of the EventDescriptor to which all of the Events in this page belong
     """
-    seq_num: List[int]
+    seq_num: list[int]
     """
     Array of sequence numbers to identify the location of each Event in the Event stream
     """
-    uid: List[str]
+    uid: list[str]
     """
     Array of globally unique identifiers for each Event
     """

--- a/src/event_model/documents/resource.py
+++ b/src/event_model/documents/resource.py
@@ -4,13 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, TypedDict
+from typing import Any, Literal, TypedDict
 
 from typing_extensions import NotRequired
 
 
 class PartialResource(TypedDict):
-    resource_kwargs: Dict[str, Any]
+    resource_kwargs: dict[str, Any]
     """
     Additional argument to pass to the Handler to read a Resource
     """

--- a/src/event_model/documents/run_start.py
+++ b/src/event_model/documents/run_start.py
@@ -4,18 +4,29 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, TypedDict, Union
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from typing_extensions import NotRequired
 
 
+class Hints(TypedDict):
+    """
+    Start-level hints
+    """
+
+    dimensions: NotRequired[list[list[list[str] | str]]]
+    """
+    The independent axes of the experiment. Ordered slow to fast
+    """
+
+
 class Calculation(TypedDict):
-    args: NotRequired[List]
+    args: NotRequired[list[Any]]
     callable: str
     """
     callable function to perform calculation
     """
-    kwargs: NotRequired[Dict[str, Any]]
+    kwargs: NotRequired[dict[str, Any]]
     """
     kwargs for calcalation callable
     """
@@ -25,46 +36,35 @@ class ConfigurationProjection(TypedDict):
     config_device: str
     config_index: int
     field: str
-    location: NotRequired[str]
+    location: Literal["configuration"]
     """
     Projection comes from configuration fields in the event_descriptor document
     """
     stream: str
-    type: NotRequired[str]
+    type: Literal["linked"]
     """
     Projection is of type linked, a value linked from the data set.
     """
 
 
-DataType = Any
-
-
-class Hints(TypedDict):
-    """
-    Start-level hints
-    """
-
-    dimensions: NotRequired[List[List[Union[List[str], str]]]]
-    """
-    The independent axes of the experiment. Ordered slow to fast
-    """
+DataType: TypeAlias = dict[str, "DataType"]
 
 
 class LinkedEventProjection(TypedDict):
     field: str
-    location: NotRequired[str]
+    location: Literal["event"]
     """
     Projection comes and event
     """
     stream: str
-    type: NotRequired[str]
+    type: Literal["linked"]
     """
     Projection is of type linked, a value linked from the data set.
     """
 
 
 class StaticProjection(TypedDict):
-    type: NotRequired[str]
+    type: Literal["static"]
     """
     Projection is of type static, a value defined here in the projection
     """
@@ -80,12 +80,12 @@ class CalculatedEventProjection(TypedDict):
     required fields if type is calculated
     """
     field: str
-    location: NotRequired[str]
+    location: Literal["event"]
     """
     Projection comes and event
     """
     stream: str
-    type: NotRequired[str]
+    type: Literal["calculated"]
     """
     Projection is of type calculated, a value that requires calculation.
     """
@@ -96,7 +96,7 @@ class Projections(TypedDict):
     Describe how to interperet this run as the given projection
     """
 
-    configuration: Dict[str, Any]
+    configuration: dict[str, Any]
     """
     Static information about projection
     """
@@ -104,14 +104,12 @@ class Projections(TypedDict):
     """
     The name of the projection
     """
-    projection: Dict[
+    projection: dict[
         str,
-        Union[
-            ConfigurationProjection,
-            LinkedEventProjection,
-            CalculatedEventProjection,
-            StaticProjection,
-        ],
+        ConfigurationProjection
+        | LinkedEventProjection
+        | CalculatedEventProjection
+        | StaticProjection,
     ]
     version: str
     """
@@ -125,7 +123,7 @@ class RunStart(TypedDict):
     later documents link to it
     """
 
-    data_groups: NotRequired[List[str]]
+    data_groups: NotRequired[list[str]]
     """
     An optional list of data access groups that have meaning to some external system. Examples might include facility, beamline, end stations, proposal, safety form.
     """
@@ -147,8 +145,8 @@ class RunStart(TypedDict):
     """
     Name of project that this run is part of
     """
-    projections: NotRequired[List[Projections]]
-    sample: NotRequired[Union[Dict[str, Any], str]]
+    projections: NotRequired[list[Projections]]
+    sample: NotRequired[dict[str, Any] | str]
     """
     Information about the sample, may be a UID to another collection
     """

--- a/src/event_model/documents/run_stop.py
+++ b/src/event_model/documents/run_stop.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Literal, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 
 from typing_extensions import NotRequired
 
-DataType = Any
+DataType: TypeAlias = Any
 
 
 class RunStop(TypedDict):
@@ -25,7 +25,7 @@ class RunStop(TypedDict):
     """
     State of the run when it ended
     """
-    num_events: NotRequired[Dict[str, int]]
+    num_events: NotRequired[dict[str, int]]
     """
     Number of Events per named stream
     """

--- a/src/event_model/documents/stream_resource.py
+++ b/src/event_model/documents/stream_resource.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, TypedDict
+from typing import Any, TypedDict
 
 from typing_extensions import NotRequired
 
@@ -23,7 +23,7 @@ class StreamResource(TypedDict):
     """
     String identifying the format/type of this Stream Resource, used to identify a compatible Handler
     """
-    parameters: Dict[str, Any]
+    parameters: dict[str, Any]
     """
     Additional keyword arguments to pass to the Handler to read a Stream Resource
     """

--- a/src/event_model/generate/create_documents.py
+++ b/src/event_model/generate/create_documents.py
@@ -1,7 +1,8 @@
 import json
+import warnings
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, Dict, Type, cast
+from typing import Any, cast
 
 import datamodel_code_generator
 from pydantic import BaseModel
@@ -53,7 +54,7 @@ def merge_dicts(dict1: dict, dict2: dict) -> dict:
     return return_dict
 
 
-def sort_alphabetically(schema: Dict) -> Dict:
+def sort_alphabetically(schema: dict) -> dict:
     """Sorts the schema alphabetically by key name, exchanging the
     properties dicts for OrderedDicts"""
     schema = OrderedDict(sorted(schema.items(), key=lambda x: x[0]))
@@ -75,7 +76,7 @@ SortOrder = {
 }
 
 
-def sort_schema(document_schema: Dict[str, Any]) -> Dict[str, Any]:
+def sort_schema(document_schema: dict[str, Any]) -> dict[str, Any]:
     assert isinstance(document_schema, dict)
     document_schema = OrderedDict(
         sorted(
@@ -99,7 +100,7 @@ def sort_schema(document_schema: Dict[str, Any]) -> Dict[str, Any]:
     return document_schema
 
 
-def dump_json(schema: Dict[str, Any], jsonschema_path: Path):
+def dump_json(schema: dict[str, Any], jsonschema_path: Path):
     """Returns true if the basemodel had to change, false otherwise"""
     sorted_schema = sort_schema(schema)
     with jsonschema_path.open(mode="w") as f:
@@ -110,20 +111,23 @@ def dump_json(schema: Dict[str, Any], jsonschema_path: Path):
 
 def generate_typeddict(jsonschema_path: Path, documents_root=TYPEDDICTS) -> Path:
     document_path = documents_root / f"{jsonschema_path.stem}.py"
-    datamodel_code_generator.generate(
-        input_=jsonschema_path,
-        input_file_type=datamodel_code_generator.InputFileType.JsonSchema,
-        output=document_path,
-        output_model_type=datamodel_code_generator.DataModelType.TypingTypedDict,
-        use_schema_description=True,
-        use_field_description=True,
-        use_annotated=True,
-        field_constraints=True,
-        wrap_string_literal=True,
-        use_double_quotes=True,
-        disable_timestamp=True,
-        custom_template_dir=TEMPLATES,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=FutureWarning)
+        datamodel_code_generator.generate(
+            input_=jsonschema_path,
+            input_file_type=datamodel_code_generator.InputFileType.JsonSchema,
+            output=document_path,
+            output_model_type=datamodel_code_generator.DataModelType.TypingTypedDict,
+            target_python_version=datamodel_code_generator.PythonVersion.PY_310,
+            use_schema_description=True,
+            use_field_description=True,
+            use_annotated=True,
+            field_constraints=True,
+            wrap_string_literal=True,
+            use_double_quotes=True,
+            disable_timestamp=True,
+            use_closed_typed_dict=False,
+        )
     with document_path.open("r+") as f:
         content = f.read()
         f.seek(0, 0)
@@ -131,15 +135,15 @@ def generate_typeddict(jsonschema_path: Path, documents_root=TYPEDDICTS) -> Path
     return document_path
 
 
-def get_jsonschema_path(jsonschema: Dict, root=JSONSCHEMA) -> Path:
+def get_jsonschema_path(jsonschema: dict, root=JSONSCHEMA) -> Path:
     return root / f"{to_snake(jsonschema['title'])}.json"
 
 
 def _generate_jsonschema(
-    basemodel: Type[BaseModel],
+    basemodel: type[BaseModel],
     jsonschema_root=JSONSCHEMA,
     is_parent: bool = False,
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     refs = []
 
     for parent in [parent for parent in basemodel.__bases__ if parent is not BaseModel]:
@@ -153,8 +157,8 @@ def _generate_jsonschema(
         )
         refs.append(parent_jsonschema)
 
-    schema_extra: Dict[str, Any] = cast(
-        Dict[str, Any], basemodel.model_config.pop("json_schema_extra", {})
+    schema_extra: dict[str, Any] = cast(
+        dict[str, Any], basemodel.model_config.pop("json_schema_extra", {})
     )
     model_jsonschema = basemodel.model_json_schema(schema_generator=SnakeCaseTitleField)
     model_jsonschema = merge_dicts(model_jsonschema, schema_extra)
@@ -189,7 +193,7 @@ def _generate_jsonschema(
 
 
 def generate_jsonschema(
-    basemodel: Type[BaseModel],
+    basemodel: type[BaseModel],
     jsonschema_root=JSONSCHEMA,
 ) -> Path:
     model_jsonschema = _generate_jsonschema(basemodel, jsonschema_root=jsonschema_root)
@@ -201,19 +205,17 @@ def generate_jsonschema(
 
 GENERATED_INIT_PY = """# generated in `event_model/generate`
 
-from typing import Tuple, Type, Union
-
 {0}
 
-{1}Type = Union[
+{1}Type = (
 {2}
-]
+)
 
-{1} = Union[
+{1} = (
 {3}
-]
+)
 
-ALL_{4}: Tuple[{1}Type, ...] = (
+ALL_{4}: tuple[{1}Type, ...] = (
 {5}
 )"""
 
@@ -240,15 +242,12 @@ def generate_init_py(output_root: Path):
         )
     )
 
-    document_types = "\n".join(
-        [
-            f"    Type[{class_name}],  # noqa: F405,"
-            for class_name in document_class_names
-        ]
+    document_types = "    " + "\n    | ".join(
+        [f"type[{class_name}]  # noqa: F405" for class_name in document_class_names]
     )
 
-    documents = "\n".join(
-        [f"    {class_name},  # noqa: F405" for class_name in document_class_names]
+    documents = "    " + "\n    | ".join(
+        [f"{class_name}  # noqa: F405" for class_name in document_class_names]
     )
 
     all_documents = "\n".join(

--- a/src/event_model/generate/templates/root.jinja2
+++ b/src/event_model/generate/templates/root.jinja2
@@ -1,8 +1,0 @@
-{%- set field = fields[0] %}
-{%- if class_name == 'DataType' %}
-{{ class_name }} = Any
-{%- elif field.annotated %}
-{{ class_name }} = {{ field.annotated }}
-{%- else %}
-{{ class_name }} = {{ field.type_hint }}
-{%- endif %}

--- a/src/event_model/schemas/datum.json
+++ b/src/event_model/schemas/datum.json
@@ -11,7 +11,8 @@
         "datum_kwargs": {
             "title": "datum_kwargs",
             "description": "Arguments to pass to the Handler to retrieve one quanta of data",
-            "type": "object"
+            "type": "object",
+            "additionalProperties": true
         },
         "resource": {
             "title": "resource",

--- a/src/event_model/schemas/event.json
+++ b/src/event_model/schemas/event.json
@@ -15,7 +15,8 @@
                 "data": {
                     "title": "data",
                     "description": "The actual measurement data",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "filled": {
                     "title": "filled",
@@ -40,7 +41,8 @@
                 "timestamps": {
                     "title": "timestamps",
                     "description": "The timestamps of the individual measurement data",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 }
             },
             "required": [

--- a/src/event_model/schemas/event_descriptor.json
+++ b/src/event_model/schemas/event_descriptor.json
@@ -11,6 +11,7 @@
                     "title": "data",
                     "description": "The actual measurement data",
                     "type": "object",
+                    "additionalProperties": true,
                     "default": {}
                 },
                 "data_keys": {
@@ -26,6 +27,7 @@
                     "title": "timestamps",
                     "description": "The timestamps of the individual measurement data",
                     "type": "object",
+                    "additionalProperties": true,
                     "default": {}
                 }
             },
@@ -378,6 +380,7 @@
             "title": "object_keys",
             "description": "Maps a Device/Signal name to the names of the entries it produces in data_keys.",
             "type": "object",
+            "additionalProperties": true,
             "default": {}
         },
         "run_start": {

--- a/src/event_model/schemas/resource.json
+++ b/src/event_model/schemas/resource.json
@@ -15,7 +15,8 @@
                 "resource_kwargs": {
                     "title": "resource_kwargs",
                     "description": "Additional argument to pass to the Handler to read a Resource",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "resource_path": {
                     "title": "resource_path",

--- a/src/event_model/schemas/run_start.json
+++ b/src/event_model/schemas/run_start.json
@@ -60,6 +60,7 @@
                     "title": "kwargs",
                     "description": "kwargs for calcalation callable",
                     "type": "object",
+                    "additionalProperties": true,
                     "default": {}
                 }
             },
@@ -190,7 +191,8 @@
                 "configuration": {
                     "title": "configuration",
                     "description": "Static information about projection",
-                    "type": "object"
+                    "type": "object",
+                    "additionalProperties": true
                 },
                 "name": {
                     "title": "name",
@@ -315,6 +317,7 @@
             "description": "Information about the sample, may be a UID to another collection",
             "anyOf": [
                 {
+                    "additionalProperties": true,
                     "type": "object"
                 },
                 {

--- a/src/event_model/schemas/stream_resource.json
+++ b/src/event_model/schemas/stream_resource.json
@@ -16,7 +16,8 @@
         "parameters": {
             "title": "parameters",
             "description": "Additional keyword arguments to pass to the Handler to read a Stream Resource",
-            "type": "object"
+            "type": "object",
+            "additionalProperties": true
         },
         "run_start": {
             "title": "run_start",

--- a/src/event_model/tests/test_run_router.py
+++ b/src/event_model/tests/test_run_router.py
@@ -342,13 +342,16 @@ def test_subfactory_callback_exception():
     rr("start", start_doc)
 
     descriptor_doc = {"run_start": "abcdef", "uid": "ghijkl"}
-    with pytest.warns(
-        UserWarning,
-        match=(
-            "Update the factory function. "
-            "In a future release this warning will become an error"
+    with (
+        pytest.warns(
+            UserWarning,
+            match=(
+                "Update the factory function. "
+                "In a future release this warning will become an error"
+            ),
         ),
-    ), pytest.raises(TestException):
+        pytest.raises(TestException),
+    ):
         rr("descriptor", descriptor_doc)
 
     assert rr._start_to_descriptors["abcdef"] == ["ghijkl"]

--- a/src/event_model/tests/test_schema_generation.py
+++ b/src/event_model/tests/test_schema_generation.py
@@ -2,9 +2,6 @@
 
 from pathlib import Path
 
-import pytest
-from pydantic.warnings import PydanticDeprecatedSince20
-
 from event_model.generate.create_documents import JSONSCHEMA, TYPEDDICTS, generate
 
 
@@ -14,8 +11,7 @@ def test_generated_json_matches_typed_dict(tmpdir: Path):
     tmp_jsonschema = Path(tmpdir) / "jsonschema"
     tmp_jsonschema.mkdir()
 
-    with pytest.warns(PydanticDeprecatedSince20):
-        generate(jsonschema_root=tmp_jsonschema, documents_root=tmp_documents)
+    generate(jsonschema_root=tmp_jsonschema, documents_root=tmp_documents)
 
     for new_jsonschema_path in tmp_jsonschema.iterdir():
         old_jsonschema_path = JSONSCHEMA / new_jsonschema_path.name


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #367 and #354 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Python 3.9 reaches EOL end of this month; this is an attempt to mirror bluesky repo.

~Currently blocked by [#1959](https://github.com/bluesky/bluesky/pull/1959)~

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally but some changes due to autogenerating typed dictionary models are fishy.

<!--
## Screenshots (if appropriate):
-->
