### PR TITLE
Made stream name required in event descriptor

### DIFF
--- a/src/event_model/basemodels/event_descriptor.py
+++ b/src/event_model/basemodels/event_descriptor.py
@@ -279,9 +279,8 @@ class EventDescriptor(BaseModel):
     name: Annotated[
         str,
         Field(
-            default="",
             description="A human-friendly name for this data stream, such as "
-            "'primary' or 'baseline'.",
+            "'primary' or 'baseline'."
         ),
     ]
     object_keys: Annotated[

--- a/src/event_model/documents/event_descriptor.py
+++ b/src/event_model/documents/event_descriptor.py
@@ -180,7 +180,7 @@ class EventDescriptor(TypedDict):
     This describes the data in the Event Documents.
     """
     hints: NotRequired[PerObjectHint]
-    name: NotRequired[str]
+    name: str
     """
     A human-friendly name for this data stream, such as 'primary' or 'baseline'.
     """

--- a/src/event_model/schemas/event_descriptor.json
+++ b/src/event_model/schemas/event_descriptor.json
@@ -373,8 +373,7 @@
         "name": {
             "title": "name",
             "description": "A human-friendly name for this data stream, such as 'primary' or 'baseline'.",
-            "type": "string",
-            "default": ""
+            "type": "string"
         },
         "object_keys": {
             "title": "object_keys",
@@ -401,6 +400,7 @@
     },
     "required": [
         "data_keys",
+        "name",
         "run_start",
         "time",
         "uid"

--- a/src/event_model/tests/test_auth.py
+++ b/src/event_model/tests/test_auth.py
@@ -48,6 +48,7 @@ def test_dots_not_allowed_in_keys():
         "uid": new_uid(),
         "data_keys": {"a": {"source": "", "dtype": "number", "shape": []}},
         "run_start": new_uid(),
+        "name": "primary",
     }
     schema_validators[DocumentNames.descriptor].validate(doc)
     # Add a legal key.
@@ -130,5 +131,6 @@ def test_good_numpy_datakeys(dtype_numpy):
             }
         },
         "run_start": new_uid(),
+        "name": "primary",
     }
     schema_validators[DocumentNames.descriptor].validate(descriptor)


### PR DESCRIPTION
The run engine will always provide this, but for legacy reasons it has always remained not required we now have decided that it is a required field.

Closes #370 