### PR TITLE
ENH: add named docs tuple

### DIFF
--- a/docs/reference/release-history.rst
+++ b/docs/reference/release-history.rst
@@ -2,6 +2,23 @@
 Release History
 ***************
 
+Unreleased
+==========
+
+Changed
+-------
+
+* Vendor StrEnum from backports.strenum
+* Use it as base class for DocumentNames (remove when dropping support for Python 3.10)
+
+Added
+-----
+
+* Add NamedDocuments for easier routing of documents in a callback
+* Route the documents by their name instead of their type
+* Pair each name with its document in a DocWrapper NamedTuple
+* Key each NamedDocument on a DocumentNames member
+
 v1.24.0 (2026-03-28)
 ====================
 

--- a/src/event_model/__init__.py
+++ b/src/event_model/__init__.py
@@ -5,7 +5,6 @@ import inspect
 import itertools
 import json
 import os
-import sys
 import threading
 import time as ttime
 import uuid
@@ -24,35 +23,12 @@ from typing import (
 import jsonschema
 import numpy
 
-# TODO: remove backport when Python 3.10 support is dropped
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:
-    from ._strenum_backport import StrEnum
-
-
-class DocumentNames(StrEnum):
-    stop = "stop"
-    start = "start"
-    descriptor = "descriptor"
-    event = "event"
-    datum = "datum"
-    resource = "resource"
-    event_page = "event_page"
-    datum_page = "datum_page"
-    stream_resource = "stream_resource"
-    stream_datum = "stream_datum"
-    bulk_datum = "bulk_datum"  # deprecated
-    bulk_events = "bulk_events"  # deprecated
-
-
-# Imported below DocumentNames because the generated documents package reads it
-# back off this module while this module is still initialising.
-from ._version import __version__  # noqa: E402
-from .documents.datum import Datum  # noqa: E402
-from .documents.datum_page import DatumPage  # noqa: E402
-from .documents.event import Event, PartialEvent  # noqa: E402
-from .documents.event_descriptor import (  # noqa: E402
+from ._version import __version__
+from .document_names import DocumentNames
+from .documents.datum import Datum
+from .documents.datum_page import DatumPage
+from .documents.event import Event, PartialEvent
+from .documents.event_descriptor import (
     Configuration,
     DataKey,
     Dtype,
@@ -61,9 +37,9 @@ from .documents.event_descriptor import (  # noqa: E402
     LimitsRange,
     PerObjectHint,
 )
-from .documents.event_page import EventPage, PartialEventPage  # noqa: E402
-from .documents.resource import PartialResource, Resource  # noqa: E402
-from .documents.run_start import (  # noqa: E402
+from .documents.event_page import EventPage, PartialEventPage
+from .documents.resource import PartialResource, Resource
+from .documents.run_start import (
     CalculatedEventProjection,
     Calculation,
     ConfigurationProjection,
@@ -73,9 +49,9 @@ from .documents.run_start import (  # noqa: E402
     RunStart,
     StaticProjection,
 )
-from .documents.run_stop import RunStop  # noqa: E402
-from .documents.stream_datum import StreamDatum, StreamRange  # noqa: E402
-from .documents.stream_resource import StreamResource  # noqa: E402
+from .documents.run_stop import RunStop
+from .documents.stream_datum import StreamDatum, StreamRange
+from .documents.stream_resource import StreamResource
 
 __all__ = [
     # Document types

--- a/src/event_model/__init__.py
+++ b/src/event_model/__init__.py
@@ -5,6 +5,7 @@ import inspect
 import itertools
 import json
 import os
+import sys
 import threading
 import time as ttime
 import uuid
@@ -13,7 +14,6 @@ import weakref
 from collections import defaultdict, deque
 from collections.abc import Callable, Generator, Iterable, Iterator
 from dataclasses import dataclass
-from enum import Enum
 from typing import (
     Any,
     Literal,
@@ -24,11 +24,35 @@ from typing import (
 import jsonschema
 import numpy
 
-from ._version import __version__
-from .documents.datum import Datum
-from .documents.datum_page import DatumPage
-from .documents.event import Event, PartialEvent
-from .documents.event_descriptor import (
+# TODO: remove backport when Python 3.10 support is dropped
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from ._strenum_backport import StrEnum
+
+
+class DocumentNames(StrEnum):
+    stop = "stop"
+    start = "start"
+    descriptor = "descriptor"
+    event = "event"
+    datum = "datum"
+    resource = "resource"
+    event_page = "event_page"
+    datum_page = "datum_page"
+    stream_resource = "stream_resource"
+    stream_datum = "stream_datum"
+    bulk_datum = "bulk_datum"  # deprecated
+    bulk_events = "bulk_events"  # deprecated
+
+
+# Imported below DocumentNames because the generated documents package reads it
+# back off this module while this module is still initialising.
+from ._version import __version__  # noqa: E402
+from .documents.datum import Datum  # noqa: E402
+from .documents.datum_page import DatumPage  # noqa: E402
+from .documents.event import Event, PartialEvent  # noqa: E402
+from .documents.event_descriptor import (  # noqa: E402
     Configuration,
     DataKey,
     Dtype,
@@ -37,9 +61,9 @@ from .documents.event_descriptor import (
     LimitsRange,
     PerObjectHint,
 )
-from .documents.event_page import EventPage, PartialEventPage
-from .documents.resource import PartialResource, Resource
-from .documents.run_start import (
+from .documents.event_page import EventPage, PartialEventPage  # noqa: E402
+from .documents.resource import PartialResource, Resource  # noqa: E402
+from .documents.run_start import (  # noqa: E402
     CalculatedEventProjection,
     Calculation,
     ConfigurationProjection,
@@ -49,9 +73,9 @@ from .documents.run_start import (
     RunStart,
     StaticProjection,
 )
-from .documents.run_stop import RunStop
-from .documents.stream_datum import StreamDatum, StreamRange
-from .documents.stream_resource import StreamResource
+from .documents.run_stop import RunStop  # noqa: E402
+from .documents.stream_datum import StreamDatum, StreamRange  # noqa: E402
+from .documents.stream_resource import StreamResource  # noqa: E402
 
 __all__ = [
     # Document types
@@ -89,21 +113,6 @@ __all__ = [
     "compose_run",
     "__version__",
 ]
-
-
-class DocumentNames(Enum):
-    stop = "stop"
-    start = "start"
-    descriptor = "descriptor"
-    event = "event"
-    datum = "datum"
-    resource = "resource"
-    event_page = "event_page"
-    datum_page = "datum_page"
-    stream_resource = "stream_resource"
-    stream_datum = "stream_datum"
-    bulk_datum = "bulk_datum"  # deprecated
-    bulk_events = "bulk_events"  # deprecated
 
 
 class DocumentRouter:

--- a/src/event_model/_strenum_backport.py
+++ b/src/event_model/_strenum_backport.py
@@ -1,0 +1,49 @@
+# StrEnum is vendored from backports.strenum 1.3.1
+# https://github.com/clbarnes/backports.strenum
+#
+# The package is verbatim copy of CPython 3.11's enum.StrEnum.
+#
+# Remove when supporting Python 3.10 is dropped.
+#
+# Copyright (c) 2001-2023 Python Software Foundation; All Rights Reserved
+#
+# Licensed under the Python Software Foundation License Version 2.
+"""Vendored backport of StrEnum from Python 3.11."""
+
+from enum import Enum
+from typing import TypeVar
+
+_S = TypeVar("_S", bound="StrEnum")
+
+
+class StrEnum(str, Enum):
+    def __new__(cls: type[_S], *values: str) -> _S:
+        if len(values) > 3:
+            raise TypeError(f"too many arguments for str(): {values}")
+        if len(values) == 1:
+            # it must be a string
+            if not isinstance(values[0], str):
+                raise TypeError(f"{values[0]!r} is not a string")
+        if len(values) >= 2:
+            # check that encoding argument is a string
+            if not isinstance(values[1], str):
+                raise TypeError(f"encoding must be a string, not {values[1]!r}")
+        if len(values) == 3:
+            # check that errors argument is a string
+            if not isinstance(values[2], str):
+                raise TypeError(f"errors must be a string, not {values[2]!r}")
+        value = str(*values)
+        member = str.__new__(cls, value)
+        member._value_ = value
+        return member
+
+    __str__ = str.__str__
+
+    @staticmethod
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: list[str]
+    ) -> str:
+        return name.lower()
+
+
+__all__ = ["StrEnum"]

--- a/src/event_model/document_names.py
+++ b/src/event_model/document_names.py
@@ -1,0 +1,23 @@
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from ._strenum_backport import StrEnum
+
+class DocumentNames(StrEnum):
+    """StrEnum of the names of all documents in the event model."""
+    stop = "stop"
+    start = "start"
+    descriptor = "descriptor"
+    event = "event"
+    datum = "datum"
+    resource = "resource"
+    event_page = "event_page"
+    datum_page = "datum_page"
+    stream_resource = "stream_resource"
+    stream_datum = "stream_datum"
+    bulk_datum = "bulk_datum"  # deprecated
+    bulk_events = "bulk_events"  # deprecated
+
+__all__ = ["DocumentNames"]

--- a/src/event_model/document_names.py
+++ b/src/event_model/document_names.py
@@ -5,8 +5,10 @@ if sys.version_info >= (3, 11):
 else:
     from ._strenum_backport import StrEnum
 
+
 class DocumentNames(StrEnum):
     """StrEnum of the names of all documents in the event model."""
+
     stop = "stop"
     start = "start"
     descriptor = "descriptor"
@@ -19,5 +21,6 @@ class DocumentNames(StrEnum):
     stream_datum = "stream_datum"
     bulk_datum = "bulk_datum"  # deprecated
     bulk_events = "bulk_events"  # deprecated
+
 
 __all__ = ["DocumentNames"]

--- a/src/event_model/documents/__init__.py
+++ b/src/event_model/documents/__init__.py
@@ -1,5 +1,13 @@
 # generated in `event_model/generate`
 
+from typing import Generic, Literal, TypeVar
+
+# TODO: import from typing when Python 3.10 support is dropped, where a
+# NamedTuple cannot yet be generic.
+from typing_extensions import NamedTuple
+
+from event_model import DocumentNames
+
 from .datum import *  # noqa: F403
 from .datum_page import *  # noqa: F403
 from .event import *  # noqa: F403
@@ -10,6 +18,20 @@ from .run_start import *  # noqa: F403
 from .run_stop import *  # noqa: F403
 from .stream_datum import *  # noqa: F403
 from .stream_resource import *  # noqa: F403
+
+NameT = TypeVar("NameT")
+DocT = TypeVar("DocT")
+
+
+class DocWrapper(Generic[NameT, DocT], NamedTuple):
+    """Named document wrapper."""
+
+    name: NameT
+    """The name each document is emitted under."""
+
+    doc: DocT
+    """The document itself."""
+
 
 DocumentType = (
     type[Datum]  # noqa: F405
@@ -35,6 +57,30 @@ Document = (
     | RunStop  # noqa: F405
     | StreamDatum  # noqa: F405
     | StreamResource  # noqa: F405
+)
+
+NamedDatum = DocWrapper[Literal[DocumentNames.datum], Datum]  # noqa: F405
+NamedDatumPage = DocWrapper[Literal[DocumentNames.datum_page], DatumPage]  # noqa: F405
+NamedEvent = DocWrapper[Literal[DocumentNames.event], Event]  # noqa: F405
+NamedEventDescriptor = DocWrapper[Literal[DocumentNames.descriptor], EventDescriptor]  # noqa: F405
+NamedEventPage = DocWrapper[Literal[DocumentNames.event_page], EventPage]  # noqa: F405
+NamedResource = DocWrapper[Literal[DocumentNames.resource], Resource]  # noqa: F405
+NamedRunStart = DocWrapper[Literal[DocumentNames.start], RunStart]  # noqa: F405
+NamedRunStop = DocWrapper[Literal[DocumentNames.stop], RunStop]  # noqa: F405
+NamedStreamDatum = DocWrapper[Literal[DocumentNames.stream_datum], StreamDatum]  # noqa: F405
+NamedStreamResource = DocWrapper[Literal[DocumentNames.stream_resource], StreamResource]  # noqa: F405
+
+NamedDocument = (
+    NamedDatum  # noqa: F405
+    | NamedDatumPage  # noqa: F405
+    | NamedEvent  # noqa: F405
+    | NamedEventDescriptor  # noqa: F405
+    | NamedEventPage  # noqa: F405
+    | NamedResource  # noqa: F405
+    | NamedRunStart  # noqa: F405
+    | NamedRunStop  # noqa: F405
+    | NamedStreamDatum  # noqa: F405
+    | NamedStreamResource  # noqa: F405
 )
 
 ALL_DOCUMENTS: tuple[DocumentType, ...] = (

--- a/src/event_model/documents/__init__.py
+++ b/src/event_model/documents/__init__.py
@@ -6,7 +6,7 @@ from typing import Generic, Literal, TypeVar
 # NamedTuple cannot yet be generic.
 from typing_extensions import NamedTuple
 
-from event_model import DocumentNames
+from event_model.document_names import DocumentNames
 
 from .datum import *  # noqa: F403
 from .datum_page import *  # noqa: F403

--- a/src/event_model/generate/create_documents.py
+++ b/src/event_model/generate/create_documents.py
@@ -227,7 +227,7 @@ from typing import Generic, Literal, TypeVar
 # NamedTuple cannot yet be generic.
 from typing_extensions import NamedTuple
 
-from event_model import DocumentNames
+from event_model.document_names import DocumentNames
 
 {imports}
 

--- a/src/event_model/generate/create_documents.py
+++ b/src/event_model/generate/create_documents.py
@@ -11,9 +11,25 @@ from pydantic.json_schema import GenerateJsonSchema
 
 from event_model.basemodels import ALL_BASEMODELS
 
+#: Path to JSON schema files.
 JSONSCHEMA = Path(__file__).parent.parent / "schemas"
+
+#: Path to TypedDict documents.
 TYPEDDICTS = Path(__file__).parent.parent / "documents"
-TEMPLATES = Path(__file__).parent / "templates"
+
+#: Name each document is emitted under, keyed by module name.
+DOCUMENT_NAMES: dict[str, str] = {
+    "datum": "datum",
+    "datum_page": "datum_page",
+    "event": "event",
+    "event_descriptor": "descriptor",
+    "event_page": "event_page",
+    "resource": "resource",
+    "run_start": "start",
+    "run_stop": "stop",
+    "stream_datum": "stream_datum",
+    "stream_resource": "stream_resource",
+}
 
 
 class SnakeCaseTitleField(GenerateJsonSchema):
@@ -205,41 +221,84 @@ def generate_jsonschema(
 
 GENERATED_INIT_PY = """# generated in `event_model/generate`
 
-{0}
+from typing import Generic, Literal, TypeVar
 
-{1}Type = (
-{2}
+# TODO: import from typing when Python 3.10 support is dropped, where a
+# NamedTuple cannot yet be generic.
+from typing_extensions import NamedTuple
+
+from event_model import DocumentNames
+
+{imports}
+
+NameT = TypeVar("NameT")
+DocT = TypeVar("DocT")
+
+
+class DocWrapper(Generic[NameT, DocT], NamedTuple):
+    \"\"\"Named document wrapper.\"\"\"
+
+    name: NameT
+    \"\"\"The name each document is emitted under.\"\"\"
+
+    doc: DocT
+    \"\"\"The document itself.\"\"\"
+
+
+{singular}Type = (
+{document_types}
 )
 
-{1} = (
-{3}
+{singular} = (
+{documents}
 )
 
-ALL_{4}: tuple[{1}Type, ...] = (
-{5}
+{named_aliases}
+
+Named{singular} = (
+{named_documents}
+)
+
+ALL_{plural}: tuple[{singular}Type, ...] = (
+{all_documents}
 )"""
 
 
 def generate_init_py(output_root: Path):
-    document_names = sorted(
+    module_names = sorted(
         [
             file.stem
             for file in output_root.iterdir()
-            if file.stem != "__init__" and file.suffix == ".py"
+            if not file.stem.startswith("_") and file.suffix == ".py"
         ]
     )
 
     document_class_names = [
-        f"{snake_to_title(document_name)}" for document_name in document_names
+        f"{snake_to_title(module_name)}" for module_name in module_names
     ]
 
     init_py_imports = "\n".join(
         sorted(
             [
-                f"from .{document_name} import *  # noqa: F403"
-                for document_name in document_names
+                f"from .{module_name} import *  # noqa: F403"
+                for module_name in module_names
             ]
         )
+    )
+
+    named_aliases = "\n".join(
+        [
+            f"Named{class_name} = DocWrapper[Literal["
+            f"DocumentNames.{DOCUMENT_NAMES[module_name]}], {class_name}]"
+            "  # noqa: F405"
+            for module_name, class_name in zip(
+                module_names, document_class_names, strict=True
+            )
+        ]
+    )
+
+    named_documents = "    " + "\n    | ".join(
+        [f"Named{class_name}  # noqa: F405" for class_name in document_class_names]
     )
 
     document_types = "    " + "\n    | ".join(
@@ -255,12 +314,14 @@ def generate_init_py(output_root: Path):
     )
 
     init_py = GENERATED_INIT_PY.format(
-        init_py_imports,
-        output_root.name.rstrip("s").title(),
-        document_types,
-        documents,
-        output_root.name.upper(),
-        all_documents,
+        imports=init_py_imports,
+        singular=output_root.name.rstrip("s").title(),
+        plural=output_root.name.upper(),
+        document_types=document_types,
+        documents=documents,
+        named_aliases=named_aliases,
+        named_documents=named_documents,
+        all_documents=all_documents,
     )
 
     with open(output_root / "__init__.py", "w") as f:

--- a/src/event_model/tests/test_named_documents.py
+++ b/src/event_model/tests/test_named_documents.py
@@ -1,0 +1,321 @@
+from typing import get_args
+
+import pytest
+
+import event_model
+from event_model import DocumentNames
+from event_model.documents import (
+    ALL_DOCUMENTS,
+    Datum,
+    DatumPage,
+    DocWrapper,
+    Event,
+    EventDescriptor,
+    EventPage,
+    NamedDocument,
+    Resource,
+    RunStart,
+    RunStop,
+    StreamDatum,
+    StreamResource,
+)
+from event_model.documents.stream_datum import StreamRange
+
+# Written out independently of the generator so that a misaligned name would be
+# caught rather than reproduced.
+EXPECTED_PAIRS = {
+    DocumentNames.datum: Datum,
+    DocumentNames.datum_page: DatumPage,
+    DocumentNames.descriptor: EventDescriptor,
+    DocumentNames.event: Event,
+    DocumentNames.event_page: EventPage,
+    DocumentNames.resource: Resource,
+    DocumentNames.start: RunStart,
+    DocumentNames.stop: RunStop,
+    DocumentNames.stream_datum: StreamDatum,
+    DocumentNames.stream_resource: StreamResource,
+}
+
+
+def named_document_pairs() -> dict[DocumentNames, type]:
+    """Document class keyed by name, taken apart from ``NamedDocument``."""
+    pairs = {}
+    for named_document in get_args(NamedDocument):
+        name_literal, document_class = get_args(named_document)
+        (name,) = get_args(name_literal)
+        pairs[name] = document_class
+    return pairs
+
+
+def compose_all_documents(tmp_path) -> list:
+    """One ``(name, doc)`` pair for every kind of document a run can emit."""
+    run_bundle = event_model.compose_run()
+    descriptor_bundle = run_bundle.compose_descriptor(
+        data_keys={
+            "motor": {"shape": [], "dtype": "number", "source": "..."},
+            "image": {
+                "shape": [512, 512],
+                "dtype": "number",
+                "source": "...",
+                "external": "FILESTORE:",
+            },
+        },
+        name="primary",
+    )
+    resource_bundle = run_bundle.compose_resource(
+        spec="TIFF", root=str(tmp_path), resource_path="stack.tiff", resource_kwargs={}
+    )
+    assert run_bundle.compose_stream_resource is not None
+    stream_resource_bundle = run_bundle.compose_stream_resource(
+        mimetype="image/tiff",
+        uri="file://localhost" + str(tmp_path) + "/test_streams",
+        data_key="det1",
+        parameters={},
+    )
+    datum_doc = resource_bundle.compose_datum(datum_kwargs={"slice": 5})
+    event_doc = descriptor_bundle.compose_event(
+        data={"motor": 0, "image": datum_doc["datum_id"]},
+        timestamps={"motor": 0, "image": 0},
+        filled={"image": False},
+        seq_num=1,
+    )
+    stream_datum_doc = stream_resource_bundle.compose_stream_datum(
+        StreamRange(start=0, stop=1), StreamRange(start=0, stop=1)
+    )
+    return [
+        (DocumentNames.start, run_bundle.start_doc),
+        (DocumentNames.descriptor, descriptor_bundle.descriptor_doc),
+        (DocumentNames.resource, resource_bundle.resource_doc),
+        (DocumentNames.stream_resource, stream_resource_bundle.stream_resource_doc),
+        (DocumentNames.datum, datum_doc),
+        (DocumentNames.datum_page, event_model.pack_datum_page(datum_doc)),
+        (DocumentNames.event, event_doc),
+        (DocumentNames.event_page, event_model.pack_event_page(event_doc)),
+        (DocumentNames.stream_datum, stream_datum_doc),
+        (DocumentNames.stop, run_bundle.compose_stop()),
+    ]
+
+
+def expected_routing(composed: list) -> dict:
+    """The field each routing branch reads, keyed by the name that selects it.
+
+    Taken from the composed documents themselves so that a branch reading the
+    right field off the wrong document fails.
+    """
+    docs = dict(composed)
+    return {
+        DocumentNames.start: docs[DocumentNames.start]["uid"],
+        DocumentNames.descriptor: sorted(docs[DocumentNames.descriptor]["data_keys"]),
+        DocumentNames.resource: docs[DocumentNames.resource]["resource_path"],
+        DocumentNames.stream_resource: docs[DocumentNames.stream_resource]["uri"],
+        DocumentNames.datum: docs[DocumentNames.datum]["datum_id"],
+        DocumentNames.datum_page: docs[DocumentNames.datum_page]["datum_id"],
+        DocumentNames.event: docs[DocumentNames.event]["seq_num"],
+        DocumentNames.event_page: docs[DocumentNames.event_page]["seq_num"],
+        DocumentNames.stream_datum: docs[DocumentNames.stream_datum]["seq_nums"],
+        DocumentNames.stop: docs[DocumentNames.stop]["exit_status"],
+    }
+
+
+def assert_every_document_was_routed(seen: dict, composed: list) -> None:
+    assert set(seen) == set(named_document_pairs())
+    assert seen == expected_routing(composed)
+    assert seen[DocumentNames.descriptor] == ["image", "motor"]
+    assert seen[DocumentNames.resource] == "stack.tiff"
+    assert seen[DocumentNames.event] == 1
+    assert seen[DocumentNames.event_page] == [1]
+    assert seen[DocumentNames.datum_page] == [seen[DocumentNames.datum]]
+    assert seen[DocumentNames.stop] == "success"
+
+
+def test_named_document_pairs_each_name_with_its_document():
+    assert named_document_pairs() == EXPECTED_PAIRS
+
+
+def test_named_document_has_an_alias_per_document():
+    pairs = named_document_pairs()
+    assert len(get_args(NamedDocument)) == len(ALL_DOCUMENTS)
+    for document_class in ALL_DOCUMENTS:
+        alias = getattr(event_model.documents, f"Named{document_class.__name__}")
+        assert alias in get_args(NamedDocument)
+        (name,) = (name for name, paired in pairs.items() if paired is document_class)
+        assert get_args(alias) == (get_args(alias)[0], document_class)
+        assert name in set(DocumentNames)
+
+
+def test_composed_documents_match_the_name_they_are_emitted_under(tmp_path):
+    """Every composed document validates against the schema its name selects."""
+    pairs = named_document_pairs()
+    composed = compose_all_documents(tmp_path)
+
+    for name, doc in composed:
+        assert name in set(DocumentNames)
+        assert set(doc) <= set(pairs[name].__annotations__)
+        validator = event_model.schema_validators[event_model.DocumentNames(name)]
+        validator.validate(doc)
+
+    assert {name for name, _ in composed} == set(pairs)
+
+
+def test_named_documents_are_keyed_on_document_names_members():
+    """Each alias is keyed on a ``DocumentNames`` member, not a bare string."""
+    for name in named_document_pairs():
+        assert isinstance(name, DocumentNames)
+        assert name == str(name)
+
+
+def route_by_if_else(named_document: NamedDocument, seen: dict) -> None:
+    """Route through an ``if``/``elif`` chain over the wrapped name."""
+    if named_document.name == DocumentNames.start:
+        seen[DocumentNames.start] = named_document.doc["uid"]
+    elif named_document.name == DocumentNames.descriptor:
+        seen[DocumentNames.descriptor] = sorted(named_document.doc["data_keys"])
+    elif named_document.name == DocumentNames.resource:
+        seen[DocumentNames.resource] = named_document.doc["resource_path"]
+    elif named_document.name == DocumentNames.stream_resource:
+        seen[DocumentNames.stream_resource] = named_document.doc["uri"]
+    elif named_document.name == DocumentNames.datum:
+        seen[DocumentNames.datum] = named_document.doc["datum_id"]
+    elif named_document.name == DocumentNames.datum_page:
+        seen[DocumentNames.datum_page] = named_document.doc["datum_id"]
+    elif named_document.name == DocumentNames.event:
+        seen[DocumentNames.event] = named_document.doc["seq_num"]
+    elif named_document.name == DocumentNames.event_page:
+        seen[DocumentNames.event_page] = named_document.doc["seq_num"]
+    elif named_document.name == DocumentNames.stream_datum:
+        seen[DocumentNames.stream_datum] = named_document.doc["seq_nums"]
+    elif named_document.name == DocumentNames.stop:
+        seen[DocumentNames.stop] = named_document.doc["exit_status"]
+    else:
+        raise AssertionError(f"{named_document.name} fell through the chain")
+
+
+def route_by_match_case(named_document: NamedDocument, seen: dict) -> None:
+    """Route through match-case value patterns over the wrapped name."""
+    match named_document.name:
+        case DocumentNames.start:
+            seen[DocumentNames.start] = named_document.doc["uid"]
+        case DocumentNames.descriptor:
+            seen[DocumentNames.descriptor] = sorted(named_document.doc["data_keys"])
+        case DocumentNames.resource:
+            seen[DocumentNames.resource] = named_document.doc["resource_path"]
+        case DocumentNames.stream_resource:
+            seen[DocumentNames.stream_resource] = named_document.doc["uri"]
+        case DocumentNames.datum:
+            seen[DocumentNames.datum] = named_document.doc["datum_id"]
+        case DocumentNames.datum_page:
+            seen[DocumentNames.datum_page] = named_document.doc["datum_id"]
+        case DocumentNames.event:
+            seen[DocumentNames.event] = named_document.doc["seq_num"]
+        case DocumentNames.event_page:
+            seen[DocumentNames.event_page] = named_document.doc["seq_num"]
+        case DocumentNames.stream_datum:
+            seen[DocumentNames.stream_datum] = named_document.doc["seq_nums"]
+        case DocumentNames.stop:
+            seen[DocumentNames.stop] = named_document.doc["exit_status"]
+        case _:
+            raise AssertionError(f"{named_document.name} matched no case")
+
+
+def route_by_match_sequence(named_document: NamedDocument, seen: dict) -> None:
+    """Route by unpacking the wrapper as the two element sequence it is."""
+    match named_document:
+        case (DocumentNames.start, doc):
+            seen[DocumentNames.start] = doc["uid"]
+        case (DocumentNames.descriptor, doc):
+            seen[DocumentNames.descriptor] = sorted(doc["data_keys"])
+        case (DocumentNames.resource, doc):
+            seen[DocumentNames.resource] = doc["resource_path"]
+        case (DocumentNames.stream_resource, doc):
+            seen[DocumentNames.stream_resource] = doc["uri"]
+        case (DocumentNames.datum, doc):
+            seen[DocumentNames.datum] = doc["datum_id"]
+        case (DocumentNames.datum_page, doc):
+            seen[DocumentNames.datum_page] = doc["datum_id"]
+        case (DocumentNames.event, doc):
+            seen[DocumentNames.event] = doc["seq_num"]
+        case (DocumentNames.event_page, doc):
+            seen[DocumentNames.event_page] = doc["seq_num"]
+        case (DocumentNames.stream_datum, doc):
+            seen[DocumentNames.stream_datum] = doc["seq_nums"]
+        case (DocumentNames.stop, doc):
+            seen[DocumentNames.stop] = doc["exit_status"]
+        case _:
+            raise AssertionError(f"{named_document.name} matched no case")
+
+
+def route_by_match_guard(named_document: NamedDocument, seen: dict) -> None:
+    """Route through match-case guards comparing the wrapped name.
+
+    Each guard reads the name off the wrapper rather than a captured binding,
+    which is what lets the guard narrow the document alongside it.
+    """
+    match named_document:
+        case _ if named_document.name == DocumentNames.start:
+            seen[DocumentNames.start] = named_document.doc["uid"]
+        case _ if named_document.name == DocumentNames.descriptor:
+            seen[DocumentNames.descriptor] = sorted(named_document.doc["data_keys"])
+        case _ if named_document.name == DocumentNames.resource:
+            seen[DocumentNames.resource] = named_document.doc["resource_path"]
+        case _ if named_document.name == DocumentNames.stream_resource:
+            seen[DocumentNames.stream_resource] = named_document.doc["uri"]
+        case _ if named_document.name == DocumentNames.datum:
+            seen[DocumentNames.datum] = named_document.doc["datum_id"]
+        case _ if named_document.name == DocumentNames.datum_page:
+            seen[DocumentNames.datum_page] = named_document.doc["datum_id"]
+        case _ if named_document.name == DocumentNames.event:
+            seen[DocumentNames.event] = named_document.doc["seq_num"]
+        case _ if named_document.name == DocumentNames.event_page:
+            seen[DocumentNames.event_page] = named_document.doc["seq_num"]
+        case _ if named_document.name == DocumentNames.stream_datum:
+            seen[DocumentNames.stream_datum] = named_document.doc["seq_nums"]
+        case _ if named_document.name == DocumentNames.stop:
+            seen[DocumentNames.stop] = named_document.doc["exit_status"]
+        case _:
+            raise AssertionError(f"{named_document.name} matched no case")
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        route_by_if_else,
+        route_by_match_case,
+        route_by_match_sequence,
+        route_by_match_guard,
+    ],
+    ids=["if_else", "match_case", "match_sequence", "match_guard"],
+)
+def test_callback_routes_named_documents(route, tmp_path):
+    """Every way of discriminating on the wrapped name routes every document."""
+    seen: dict = {}
+
+    composed = compose_all_documents(tmp_path)
+    for name, doc in composed:
+        route(DocWrapper(name, doc), seen)
+
+    assert_every_document_was_routed(seen, composed)
+
+
+def test_document_router_emits_named_documents(tmp_path):
+    """An unchanged two-argument callback still receives each document by name.
+
+    The router emits a name and a document as two arguments, so a caller pairs
+    them up itself. A wrapper built from the pair compares equal to it.
+    """
+    pairs = named_document_pairs()
+    collected: list = []
+
+    def collect(name, doc):
+        collected.append((name, doc))
+
+    router = event_model.DocumentRouter(emit=collect)
+    composed = compose_all_documents(tmp_path)
+    for name, doc in composed:
+        router.emit(name, doc)
+
+    assert len(collected) == len(composed)
+    for pair in collected:
+        assert len(pair) == 2
+        name, doc = pair
+        assert DocWrapper(name, doc) == pair
+        assert set(doc) <= set(pairs[name].__annotations__)


### PR DESCRIPTION
Closes #369

I got some help from Claude for this. I honestly let him roll the tests on its own to give it a whirl but have NOT properly reviewed them. I'm opening the PR but I'll leave it as draft to confirm that the tests make sense, hoping to get another pair of eyes as well.

The PR does two things:

- vendors [`backports.strenum`](https://pypi.org/project/backports.strenum/) to convert `DocumentNames` to a `StrEnum`; when Python 3.10 is dropped from support the vendor can be removed;
- adds a `DocWrapper` helper for leveraging match-case on the document name.

`DocWrapper` is a named tuple that encapsulates the document name as an enum value from DocumentNames and the actual document type. Typically callbacks are type annotated as:

```py
# Document is the union of all possible
# document types
from event_model import Document

def my_callback(name: str, doc: Document) -> None:
```

This makes it hard for users that wish to type annotate their callbacks to properly discern between different document types without having to rely on `# type: ignore` or `typing.cast`.

Using `DocumentNames` as a `StrEnum` and adding a `NamedDocument` union that packs the enum to its respective document type, we can do something like this:

```py
from event_model import NamedDocument, DocumentNames

def my_callback(doc: NamedDocument) -> None:
    match doc.name:
          case DocumentNames.start:
              reveal_type(doc.doc) # revealed type is RunStart
    if doc.name == Document.start:
        reveal_type(doc.doc) # revealed type is RunStart
```

Initially the attempt was to support *both* raw strings **and** StrEnum as a narrower for the document type. Apparently this is not possible. Our thought (mine and @evvaaaa) is that we should encourage users that wish for a more type-safe approach in this callback to use this narrowing policy via enumerators.